### PR TITLE
Add `-b` flag to control where LLVM bitcode files will be output to.

### DIFF
--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -34,6 +34,8 @@ pub struct BitcodeOptions {
     // pub input : PathBuf,
     #[structopt(long="clang", help="Name of the clang binary to use to generate bitcode (default: `clang`)")]
     pub clang_path : Option<PathBuf>,
+    #[structopt(short="b", long="bc-out", help="Directory to place LLVM bitcode (bc) output data.  The default is to place it next to the object file, but it must be accessible by a subsequent Extract operation and some build tools build in a temporary directory that is disposed of at the end of the build (e.g. CMake) ")]
+    pub bcout_path : Option<PathBuf>,
     #[structopt(short="v", long="verbose", help="Generate verbose output")]
     pub verbose : bool,
     #[structopt(last = true, help="The build command to run")]


### PR DESCRIPTION
Default behavior is to write the .bc file in the same location as the
.o file was generated, but this allows an override.  This can be used
for situations where the .o location is no longer valid/writeable by
the time the llvm bitcode generation operation is performed.