### PR TITLE
Add summary stats for attempts and successes in capturing LLVM bitcode.

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -138,6 +138,8 @@ pub fn bitcode_entrypoint(bitcode_options : &BitcodeOptions) -> anyhow::Result<i
     println!(" {} inputs skipped due to being only assembled (-S)", summary.skipping_assemble_only);
     println!(" {} bitcode compilation errors", summary.bitcode_compile_errors);
     println!(" {} errors attaching bitcode to object files", summary.bitcode_attach_errors);
+    println!(" {} attempts at generating bitcode", summary.bitcode_generation_attempts);
+    println!(" {} successful bitcode captures", summary.bitcode_captures);
 
     let tracee = ptracer1.wait()?;
     match tracee {
@@ -158,7 +160,9 @@ pub enum Event {
     BuildFailureUnknownEffect(RunCommand, i32),
     SkippingAssembleOnlyCommand(RunCommand),
     BitcodeCompileError(PathBuf, Vec<OsString>,Vec<u8>,Vec<u8>,Option<i32>),
-    BitcodeAttachError(PathBuf, Vec<OsString>,Vec<u8>,Vec<u8>,Option<i32>)
+    BitcodeAttachError(PathBuf, Vec<OsString>,Vec<u8>,Vec<u8>,Option<i32>),
+    BitcodeGenerationAttempts,
+    BitcodeCaptured
 }
 
 fn build_bitcode_compile_only(chan : &mut mpsc::Sender<Option<Event>>,
@@ -231,6 +235,8 @@ fn build_bitcode_compile_only(chan : &mut mpsc::Sender<Option<Event>>,
             }
         }
     }
+
+    let _res = chan.send(Some(Event::BitcodeGenerationAttempts));
 
     let child = process::Command::new(&bc_command).
         args(&modified_args).
@@ -382,6 +388,8 @@ fn attach_bitcode(chan : &mut mpsc::Sender<Option<Event>>,
                                                     out.stderr,
                                                     out.status.code());
                 let _res = chan.send(Some(err))?;
+            } else {
+                    let _res = chan.send(Some(Event::BitcodeCaptured));
             }
 
             Ok(())
@@ -399,7 +407,9 @@ struct SummaryStats {
     build_failures_unknown_effect : usize,
     skipping_assemble_only : usize,
     bitcode_compile_errors : usize,
-    bitcode_attach_errors : usize
+    bitcode_attach_errors : usize,
+    bitcode_generation_attempts : usize,
+    bitcode_captures : usize
 }
 
 fn collect_events(stream_errors : bool, chan : mpsc::Receiver<Option<Event>>) -> SummaryStats {
@@ -409,7 +419,9 @@ fn collect_events(stream_errors : bool, chan : mpsc::Receiver<Option<Event>>) ->
                                      build_failures_unknown_effect : 0,
                                      skipping_assemble_only : 0,
                                      bitcode_compile_errors : 0,
-                                     bitcode_attach_errors : 0
+                                     bitcode_attach_errors : 0,
+                                     bitcode_generation_attempts : 0,
+                                     bitcode_captures : 0
     };
     loop {
         match chan.recv() {
@@ -465,6 +477,12 @@ fn collect_events(stream_errors : bool, chan : mpsc::Receiver<Option<Event>>) ->
                             println!("  stdout: {}", String::from_utf8_lossy(&stdout).into_owned());
                             println!("  stderr: {}", String::from_utf8_lossy(&stderr).into_owned());
                         }
+                    }
+                    Event::BitcodeGenerationAttempts => {
+                        summary.bitcode_generation_attempts += 1;
+                    }
+                    Event::BitcodeCaptured => {
+                        summary.bitcode_captures += 1;
                     }
                 }
             }


### PR DESCRIPTION
Previously there was no indication of the number of successes, only counts of explicit failures.  This provides additional summary statistics to indicate possible attempts and actual successes in capturing bitcode output.