### PR TITLE
Ensure build-bom exit code matches build command exit code

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -763,7 +763,7 @@ fn generate_bitcode(chan : &mut mpsc::Sender<Option<Event>>,
                     mut ptracer : pete::Ptracer,
                     clang_path : &OsStr,
                     bcout_path : std::option::Option<&PathBuf>
-) -> anyhow::Result<pete::Ptracer> {
+) -> anyhow::Result<(pete::Ptracer, i32)> {
     let mut process_state = HashMap::new();
     let syscalls = load_syscalls();
     let mut last_exitcode = 0;


### PR DESCRIPTION
The existing code sets an exit code if there is a tracee returned, otherwise it exits with zero.  However, the internal routine monitoring the trace loops until the return is not `Ok`, which results in returning `None` for the tracee value.  This adds capture of the last execution's exit code to use when the `tracee` is `None`.