### PR TITLE
Enable debug and suppress optimization if allowed for bitcode generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "build-bom"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -39,7 +39,9 @@ pub struct BitcodeOptions {
     #[structopt(short="v", long="verbose", help="Generate verbose output")]
     pub verbose : bool,
     #[structopt(last = true, help="The build command to run")]
-    pub command : Vec<String>
+    pub command : Vec<String>,
+    #[structopt(short="f", long="flags-unchanged", help="Do not adjust flags (e.g. disable optimization) when generating bitcode")]
+    pub original_flags : bool
 }
 
 #[derive(Debug,StructOpt)]

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -66,7 +66,7 @@ fn test_zlib() -> anyhow::Result<()> {
     conf.run()?;
 
     let cmd_opts = vec![String::from("make")];
-    let gen_opts = BitcodeOptions { clang_path: user_clang_cmd(), bcout_path: None, verbose: false, command: cmd_opts };
+    let gen_opts = BitcodeOptions { clang_path: user_clang_cmd(), bcout_path: None, verbose: false, original_flags: false, command: cmd_opts };
     gen_bitcode(gen_opts)?;
 
     let mut so_path = std::path::PathBuf::new();


### PR DESCRIPTION
When generating bitcode, the `-g` flag is always supplied to add debug
information to the output bitcode file.  The `-O0` flag will be
specified as well to suppress optimization, unless the new
`--flags-unchanged`/`-f` argument is specified, in which case the
optimization setting (if any) of the original compilation command will
be passed to the bitcode generation as well.