### PR TITLE
README: Update documentation of CLI flags 

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,6 @@ In the next step, the tool extracts all of the accumulated bitcode.
 
 The ~generate-bitcode~ command has a number of options that may be useful in various contexts.
 
-- ~--dry-run~: Replays the build without taking action
 - ~--clang~: Specify the full name (or path if desired) of a clang binary to use
 - ~--suppress-automatic-debug~: By default, ~build-bom~ automatically adds the ~-g~ flag when building bitcode to generate debug information; this flag inhibits this behavior
 - ~--inject-argument=STRING~: Directs ~build-bom~ to inject an additional argument (~STRING~) into the command line for the command used to build bitcode (e.g., to configure the optimization level or level of debug information); can be specified multiple times

--- a/README.org
+++ b/README.org
@@ -36,6 +36,7 @@ In the next step, the tool extracts all of the accumulated bitcode.
 
 The ~generate-bitcode~ command has a number of options that may be useful in various contexts.
 
+- ~--bc-out~: Directory to place LLVM bitcode (bc) output data
 - ~--clang~: Specify the full name (or path if desired) of a clang binary to use
 - ~--suppress-automatic-debug~: By default, ~build-bom~ automatically adds the ~-g~ flag when building bitcode to generate debug information; this flag inhibits this behavior
 - ~--inject-argument=STRING~: Directs ~build-bom~ to inject an additional argument (~STRING~) into the command line for the command used to build bitcode (e.g., to configure the optimization level or level of debug information); can be specified multiple times


### PR DESCRIPTION
```
build-bom-generate-bitcode 0.2.0

USAGE:
    build-bom generate-bitcode [FLAGS] [OPTIONS] [-- <command>...]

FLAGS:
    -h, --help                        Prints help information
        --suppress-automatic-debug    Prevent `build-bom` from automatically injecting flags to generate debug
                                      information in bitcode files
    -V, --version                     Prints version information
    -v, --verbose                     Generate verbose output

OPTIONS:
    -b, --bc-out <bcout-path>
            Directory to place LLVM bitcode (bc) output data.  The default is to place it next to the object file, but
            it must be accessible by a subsequent Extract operation and some build tools build in a temporary directory
            that is disposed of at the end of the build (e.g. CMake) 
        --clang <clang-path>
            Name of the clang binary to use to generate bitcode (default: `clang`)

        --inject-argument <inject-arguments>...
            Have `build-bom` inject the given argument into the argument list when generating bitcode

        --remove-argument <remove-arguments>...
            Have `build-bom` remove arguments matching the given regular expression when generating bitcode


ARGS:
    <command>...    The build command to run
```