### PR TITLE
Stop on build-bom errors during testing

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -8,21 +8,21 @@
 //
 // Event:
 //
-// * syscall_enter -- if this is an execve syscall, the execve target
-//                    may be a clang invocation on a source code file.
-//                    At syscall entry, the cmdline arguments are
-//                    captured for that determination later.
+// * SyscallEnter -- if this is an execve syscall, the execve target
+//                   may be a clang invocation on a source code file.
+//                   At syscall entry, the cmdline arguments are
+//                   captured for that determination later.
 //
-// * syscall_exit -- if this is the exit from an execve syscall and it
-//                   failed, the preserved arguments from above can be
-//                   discarded.  Note that even if this is an execve,
-//                   the syscall has returned to the *original*
-//                   executable (albeit to libc library code therein),
-//                   so this does *not* represent successfull
-//                   completion of the exec'd target (which may or may
-//                   not be clang).  Thus, a successful syscall_exit
-//                   leaves the cmdline argument information available
-//                   and is otherwise ignored.
+// * SyscallExit -- if this is the exit from an execve syscall and it
+//                  failed, the preserved arguments from above can be
+//                  discarded.  Note that even if this is an execve,
+//                  the syscall has returned to the *original*
+//                  executable (albeit to libc library code therein),
+//                  so this does *not* represent successfull
+//                  completion of the exec'd target (which may or may
+//                  not be clang).  Thus, a successful syscall_exit
+//                  leaves the cmdline argument information available
+//                  and is otherwise ignored.
 //
 // * Exec -- this is the trace that records the actual change of
 //           executable code to the new target.  This is actually

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -176,6 +176,10 @@ pub fn bitcode_entrypoint(bitcode_options : &BitcodeOptions) -> anyhow::Result<i
     let summary = event_consumer.join().unwrap();
     let exitmod =
         if bitcode_options.any_fail && summary.has_failures() {
+            // If the mainline succeeded (ec == 0), return an error indicating
+            // that the bitcode-generation attempt failed.  This just needs to be
+            // a non-zero value; 76 is arbitrarily chosen as possibly
+            // recognizeable for tests.
             |ec| if ec == 0 { 76 } else { ec }
         } else {
             |ec| ec

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -46,7 +46,16 @@ pub struct BitcodeOptions {
     #[structopt(last = true, help="The build command to run")]
     pub command : Vec<String>,
     #[structopt(long="strict", help="Generate bitcode that strictly adheres to the target object code (optimization levels, target architecture, etc.).")]
-    pub strict : bool
+    pub strict : bool,
+
+    // The following is for testing only: if set, it will fail if any portion of
+    // the generate_bitcode operations fail.  In normal operation, this is false
+    // which means that the build-bom operation proceeds as long as the main
+    // compilation attempt is successful (i.e. any errors during bitcode
+    // generation are logged and counted but do not cause an overall failure
+    // result).
+    #[structopt(skip)]
+    pub any_fail : bool
 }
 
 #[derive(Debug,StructOpt)]

--- a/tests/sources/blddir_test/Makefile
+++ b/tests/sources/blddir_test/Makefile
@@ -1,0 +1,24 @@
+CC := gcc
+CFLAGS :=  -Wall -Werror -g
+
+blddir/bin/hello-world: blddir/obj/intermediate.obj blddir/obj/t.obj blddir/bin
+	cd blddir/bin;	$(CC) $(CFLAGS) -o hello-world ../obj/intermediate.obj ../obj/t.obj
+
+blddir/obj/intermediate.obj: hello-world.c blddir/obj headers/target.h
+	cd blddir/obj; $(CC) $(CFLAGS) -c -I../../headers -o intermediate.obj ../../"$<"
+
+blddir/obj/t.obj: target.c blddir/obj headers/target.h
+	cd blddir/obj; $(CC) $(CFLAGS) -c -o t.obj -I ../../headers ../../"$<"
+
+blddir/bin:
+	mkdir -p $@
+blddir/obj:
+	mkdir -p $@
+
+.DEFAULT: build
+.PHONY: build
+build: hello-world
+
+.PHONY: clean
+clean:
+	rm -rf blddir

--- a/tests/sources/blddir_test/headers/target.h
+++ b/tests/sources/blddir_test/headers/target.h
@@ -1,0 +1,1 @@
+char* get_target(int);

--- a/tests/sources/blddir_test/hello-world.c
+++ b/tests/sources/blddir_test/hello-world.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "target.h"
+
+int main() {
+    printf("Hello, %s!\n", get_target(0));
+}

--- a/tests/sources/blddir_test/target.c
+++ b/tests/sources/blddir_test/target.c
@@ -1,0 +1,8 @@
+#include "target.h"
+
+char* get_target(int name) {
+    if (name == 0) {
+        return "world";
+    }
+    return "everyone";
+}

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -193,7 +193,10 @@ fn test_zlib() -> anyhow::Result<()> {
                                     remove_arguments: Vec::new(),
                                     verbose: false,
                                     strict: false,
-                                    command: cmd_opts };
+                                    command: cmd_opts,
+                                    any_fail: false };
+    // n.b. any_fail must be false because zlib runs autoconf/configure and the
+    // failures there are tallied and cause build-bom to exit with a failure.
     gen_bitcode(gen_opts)?;
 
     let mut so_path = std::path::PathBuf::new();
@@ -238,7 +241,8 @@ fn test_no_compile_only() -> anyhow::Result<()> {
                                     remove_arguments: Vec::new(),
                                     verbose: false,
                                     strict: false,
-                                    command: cmd_opts };
+                                    command: cmd_opts,
+                                    any_fail: true };
     gen_bitcode(gen_opts)?;
     eprintln!("## bitcode generation complete");
 


### PR DESCRIPTION
Build-bom normally performs all bitcode generation operations behind the scenes and does not propagate errors from those operations out to the main build.  This is the desired operational mode for normal use, but when doing local testing of build-bom itself, stopping on *any* error is more useful.   This patch introduces a new option that is only settable by code (not by any command-line flag) which causes build-bom to stop on any failure.

This also adds a new test and cleans up some minor source elements.