### PR TITLE
Use abstraction to handle chained subprocess operations.

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -477,7 +477,7 @@ pub enum BitcodeError {
 ///
 /// Detailed explanation:
 /// ---------------------
-//
+///
 /// The ccache tool provides a "clang" target in the PATH, which is
 /// actually a symlink to the ccache executable: the ccache executable
 /// will issue a pre-proc only (-E) actual clang operation and compare
@@ -607,7 +607,7 @@ fn attach_bitcode(cwd : &Path,
     // Define the args in the order that matches the args in the calling() above.
     mktar.set_input(&FileSpec::Append(NamedFile::temp("")));
     mktar.set_output(&FileSpec::Append(NamedFile::temp(".tar")));
-    let mut reprname = bc_args.ops.out_file_for_chain().unwrap_or(PathBuf::from("unk.bc"));
+    let mut reprname = bc_args.ops.out_file_for_chain().unwrap_or_else(|| PathBuf::from("unk.bc"));
     reprname.set_extension("bc");
     mktar.push_arg(reprname);
 

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -291,10 +291,9 @@ fn build_bitcode_arguments(chan : &mut mpsc::Sender<Option<Event>>,
             }
         }
 
-        // If the argument specifies the output file, we need to munge the name
-        // of the output file (which is either the remainder of this argument or
-        // the next argument) to have an appropriate extension and to put it in
-        // the requested bitcode directory (if any)
+        // If the argument specifies the output file, note that here.  If no
+        // argument explicitly specifies an output file then it will need to be
+        // inferred (later below) from the input files.
         if arg.to_str().unwrap().starts_with("-o") {
             if arg == "-o" {
                 match it.next() {

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -267,25 +267,23 @@ fn build_bitcode_arguments(chan : &mut mpsc::Sender<Option<Event>>,
 
     // Next, copy over all of the flags we want to keep
     let mut it = orig_args.iter();
-    let mut skip_next = false;
     while let Some(arg) = it.next() {
-        // Skip value argument to a previous blacklisted argument
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
 
         // Skip any arguments explicitly blacklisted
         if clang_support::is_blacklisted_clang_argument(bc_opts.strict, arg) {
-            skip_next = clang_support::next_arg_is_option_value(arg);
+            if clang_support::next_arg_is_option_value(arg) {
+                it.next();  // skip next argument
+            }
             continue;
         }
 
         if arg.to_str().map_or(false, |s| bc_opts.remove_arguments.is_match(s)) {
-            // Reject arguments matching any of the user-provided regexes.  Note
-            // that this is of course as unsafe as users make it.  In
-            // particular, rejecting '-o' would be very bad.
-            skip_next = clang_support::next_arg_is_option_value(arg);  // hopeful here...
+            // Reject argument because it matches one of the user-provided
+            // regexes.  Note that this is of course as unsafe as users make it.
+            // In particular, rejecting '-o' would be very bad.
+            if clang_support::next_arg_is_option_value(arg) {
+                it.next();
+            }
             continue;
         } else {
             if ! arg.to_str().unwrap().starts_with("-o") {

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -110,8 +110,6 @@ pub enum TracerError {
 struct BCOpts<'a> {
     /// The clang command to use to generate bitcode
     clang_path : &'a OsString,
-    /// The directory to store generated bitcode in
-    bitcode_directory : &'a Option<&'a PathBuf>,
     /// If true, do *not* force the generation of debug information
     suppress_automatic_debug : bool,
     /// Arguments to inject when building bitcode
@@ -165,7 +163,6 @@ pub fn bitcode_entrypoint(bitcode_options : &BitcodeOptions) -> anyhow::Result<i
 
     let bc_opts = BCOpts { clang_path : &bitcode_options.clang_path.as_ref().map(|s| OsString::from(s.as_path().as_os_str()))
                                                         .unwrap_or(OsString::from("clang")),
-                           bitcode_directory : &bitcode_options.bcout_path.as_ref(),
                            suppress_automatic_debug : bitcode_options.suppress_automatic_debug,
                            inject_arguments : &bitcode_options.inject_arguments,
                            remove_arguments : &remove_rx,
@@ -1108,7 +1105,6 @@ mod tests {
         bcdir.push("to");
         bcdir.push("bitcode");
         let bcopts = BCOpts { clang_path: &"/path/to/clang".into(),
-                              bitcode_directory: &Some(&bcdir),
                               suppress_automatic_debug: false,
                               inject_arguments: &Vec::from(
                                   [ "-arg1",

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -1124,8 +1124,8 @@ mod tests {
                        "-march=mips",
                        "-DDebug",
                        "bar.c" ].map(|s| s.into());
-        let bcargs1 = build_bitcode_arguments(&mut sender, &bcopts, &args);
-        match bcargs1 {
+        let bcargs0 = build_bitcode_arguments(&mut sender, &bcopts, &args);
+        match bcargs0 {
             Err(e) => assert_eq!(e.to_string(), "<no error expected>"),
             Ok(a) => {
                 // This isn't a great way to check the contents of a

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -368,7 +368,7 @@ fn build_bitcode_compile_only(chan : &mut mpsc::Sender<Option<Event>>,
                 let _res = chan.send(Some(Event::BitcodeGenerationAttempts));
                 let bctarget = bc_args.resolved_object_target.clone();
                 attach_bitcode(cwd, &mut bc_args, &bctarget)?;
-                let ops_result = bc_args.ops.execute(&Some(cwd));
+                let ops_result = bc_args.ops.execute(&Some(cwd), false);
                 match ops_result {
                     Err(e) => {
                         let _ = // Ignore chan.send errors

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -1122,6 +1122,7 @@ mod tests {
         // Simple cmdline specification
         let args = [ "-g", "-O1", "-o", "foo.obj",
                        "-march=mips",
+                       "-I", "src/include",
                        "-DDebug",
                        "bar.c" ].map(|s| s.into());
         let bcargs0 = build_bitcode_arguments(&mut sender, &bcopts, &args);
@@ -1145,6 +1146,7 @@ mod tests {
                                          \"-arg2\", \
                                          \"arg2val\", \
                                          \"-g\", \
+                                         \"-I\", \"src/include\", \
                                          \"-DDebug\", \
                                          \"bar.c\"], \
                                   inp_file: Unneeded, \
@@ -1183,6 +1185,7 @@ mod tests {
                                          \"-g\", \
                                          \"-O1\", \
                                          \"-march=mips\", \
+                                         \"-I\", \"src/include\", \
                                          \"-DDebug\", \
                                          \"bar.c\"], \
                                   inp_file: Unneeded, \
@@ -1207,7 +1210,7 @@ mod tests {
                                                    "-O",
                                                    "--this=remove-also",
                                                    "-DDebug",
-                                                   "bar.c"
+                                                   "bar.cc"
                                               ].map(|s| s.into()));
         match bcargs2 {
             Err(e) => assert_eq!(e.to_string(), "<no error expected>"),
@@ -1226,7 +1229,7 @@ mod tests {
                                          \"-arg2\", \
                                          \"arg2val\", \
                                          \"-DDebug\", \
-                                         \"bar.c\"], \
+                                         \"bar.cc\"], \
                                   inp_file: Unneeded, \
                                   out_file: Option(\"-o\", Temp(\".bc\")), \
                                   in_dir: None \

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -134,13 +134,25 @@ pub enum FileSpec {
     #[default]
     Unneeded,
 
-    /// Append the named file to the command string
+    /// Append the named file to the command string.
     Append(NamedFile),
 
-    /// first string is the option to emit, which will be followed by the file
+    /// First string is the option to emit, which will be followed by the file.
+    /// For example, Option("-f", Actual("foo.bar")) will generate:
+    ///    cmd ... -f foo.bar ...
     Option(String, NamedFile),
 
-    /// replace the specified text in any argument with the named file.
+    /// Replace the specified text in any argument with the named file.  For
+    /// example, Replace("OUTFILE", Actual("foo.bar")) will cause a command
+    /// statement like:
+    ///
+    ///    cmd -x -y --out=OUTFILE;style=json -z
+    ///
+    /// to be updated to:
+    ///
+    ///    cmd -x -y --out=foo.bar;style=json -z
+    ///
+    /// before running the command.
     Replace(String, NamedFile)
 
     // ReplaceOrAppend(String, NamedFile),  // first string string is the marker (in args) to be replaced with the file specified as the second string.  If the marker never appears, fallback to Append behavior.

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -316,10 +316,16 @@ enum Operation {
     /// Name of executable to invoke in subprocess
     Execute(OsString),
 
-    /// Local function to call instead of executing a subprocess.  The first
-    /// argument is the reference directory , the second is the argument vector
-    /// (the input and output files will be part of the argument vector as
-    /// determined by their corresponding FileSpec).
+    /// Local function to call instead of executing a subprocess.  This is useful
+    /// for when local processing should be executed at this point in the chain.
+    /// Avoids the need to create multiple chains around this functionality.  For
+    /// example, a chain of operations that midway through creates a tar file
+    /// could Execute("tar") or it could Call a function that uses the rust
+    /// `tar::Builder` to generate the tar file via rust functionality.
+    ///
+    /// The first argument is the reference directory , the second is the
+    /// argument vector (the input and output files will be part of the argument
+    /// vector as determined by their corresponding FileSpec).
     ///
     /// The reference directory would be the current directory for the
     /// command had it been execute as a sub-process (via Operation::Execute).

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -106,22 +106,22 @@ impl NamedFile {
     /// the specified suffix.  If no particular suffix is needed, a blank suffix
     /// value should be specified.
     pub fn temp<T>(suffix: T) -> NamedFile
-    where String: From<T>
+    where T: Into<String>
     {
-        NamedFile::Temp(String::from(suffix))
+        NamedFile::Temp(suffix.into())
     }
 
     /// Generates a reference to an actual file
     pub fn actual<T>(fpath: T) -> NamedFile
-    where PathBuf: From<T>
+    where T: Into<PathBuf>
     {
-        NamedFile::Actual(PathBuf::from(fpath))
+        NamedFile::Actual(fpath.into())
     }
 
     pub fn glob_in<T,U>(dpath: T, glob: U) -> NamedFile
-    where PathBuf: From<T>, String: From<U>
+    where T: Into<PathBuf>, U: Into<String>
     {
-        NamedFile::GlobIn(PathBuf::from(dpath), String::from(glob))
+        NamedFile::GlobIn(dpath.into(), glob.into())
     }
 }
 
@@ -385,10 +385,10 @@ impl SubProcOperation {
                       inp_file : &FileSpec,
                       out_file : &FileSpec)
                       -> SubProcOperation
-    where OsString: From<&'a T>
+    where T: Into<OsString>, T: AsRef<std::ffi::OsStr>
     {
         SubProcOperation {
-            cmd : Operation::Execute(OsString::from(cmd)),
+            cmd : Operation::Execute(cmd.into()),
             args : Vec::new(),
             inp_file : inp_file.clone(),
             out_file : out_file.clone(),
@@ -425,9 +425,9 @@ impl SubProcOperation {
     /// Adds a command-line argument to use when executing the command.
     #[inline]
     pub fn push_arg<T>(&mut self, arg: T) -> &SubProcOperation
-    where OsString: From<T>
+    where T: Into<OsString>
     {
-        self.args.push(OsString::from(arg));
+        self.args.push(arg.into());
         self
     }
 
@@ -797,10 +797,10 @@ impl ChainedSubOps
     /// ChainedOpRef::set_dir() function has been called for this operation,
     /// which overrides the default directory passed to this command.
     pub fn execute<T>(&self, cwd: &Option<T>) -> anyhow::Result<usize>
-    where PathBuf: From<T>, T: Clone
+    where T: Into<PathBuf>, T: Clone
     {
         let curdir = match &cwd {
-            Some(p) => PathBuf::from(p.clone()),
+            Some(p) => p.clone().into(),
             None => current_dir()?
         };
         let chops = self.chops.borrow();
@@ -852,11 +852,11 @@ impl ChainedOpRef {
     /// Add an argument to this operation in the chain
     #[inline]
     pub fn push_arg<T>(&self, arg: T) -> &ChainedOpRef
-    where OsString: From<T>
+    where T: Into<OsString>
     {
         {
             let mut ops: RefMut<_> = self.chop.borrow_mut();
-            ops.chain[self.opidx].args.push(OsString::from(arg));
+            ops.chain[self.opidx].args.push(arg.into());
         }
         self
     }

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -784,7 +784,6 @@ impl ChainedSubOps
                           None => vec![]
                       },
                       &chops.final_out_file)
-            .map(|r| r + 1)
     }
 }
 

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -1102,8 +1102,6 @@ mod tests {
         let record_exec = move |cwd : &Path, args| Ok(
                     erec.borrow_mut().push(Called(cwd.to_path_buf(), args)));
 
-        // exec.borrow_mut().push(Called("nowhere".into(), (&[]).to_vec()));
-
         let rslt = {
             let op1 = ops.push_op(SubProcOperation::calling(record_exec.clone()));
             op1.set_input(&FileSpec::Unneeded);
@@ -1130,7 +1128,6 @@ mod tests {
             // creating a tempdir with specific files populating that tempdir...
             op4.set_input(&FileSpec::Append(NamedFile::glob_in(".", "LICENSE-*")));
             op4.set_output(&FileSpec::Unneeded);
-            // op4.set_output(&FileSpec::Append(NamedFile::temp(".glob-out")));
             op4.push_arg("--opnum=4");
 
             let op5 = ops.push_op(SubProcOperation::calling(record_exec.clone()));

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -242,17 +242,15 @@ impl FileSpec {
                     NamedFile::Temp(sfx) => {
                         let tf = tempfile::Builder::new().suffix(sfx).tempfile()?;
                         let tfs = OsString::from(tf.path());
-                        *args =
-                            args.into_iter()
-                            .map(|arg| replace(needle, &tfs, arg))
-                            .collect();
+                        for arg in args {
+                            *arg = replace(needle, &tfs, arg)
+                        }
                         Ok(SubProcFile::TempOutputFile(tf))
                     }
                     NamedFile::Actual(fpath) => {
-                        *args =
-                            args.into_iter()
-                            .map(|arg| replace(needle, &fpath.into(), arg))
-                            .collect();
+                        for arg in args {
+                            *arg = replace(needle, &fpath.into(), arg);
+                        }
                         Ok(SubProcFile::StaticOutputFile(fpath.clone()))
                     }
                     NamedFile::GlobIn(dpath, glob) => {
@@ -263,10 +261,9 @@ impl FileSpec {
                                     .map(|x| x.to_str().unwrap())
                                     .collect::<Vec<_>>()
                                     .join(",");
-                                *args =
-                                    args.into_iter()
-                                    .map(|arg| replace(needle, &allfiles.clone().into(), arg))
-                                    .collect();
+                                for arg in &mut *args {
+                                    *arg = replace(needle, &allfiles.clone().into(), arg);
+                                }
                                 Ok(SubProcFile::NoOutputFile)
                             })
                     }

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -79,7 +79,6 @@ use std::rc::Rc;
 
 
 /// Designates a type of file that can be identified by name on the command line.
-#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub enum NamedFile {
     /// Create a temporary file; str is suffix to give temporary filename
@@ -129,7 +128,6 @@ impl NamedFile {
 
 /// Determines how a file should be specified for the associated command when
 /// issuing the command at execution time.
-#[non_exhaustive]
 #[derive(Clone, Debug, Default)]
 pub enum FileSpec {
     /// No file is expressed or needed

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -465,6 +465,13 @@ impl SubProcOperation {
     /// input and output files will be determined and added to the command-line
     /// as indicated by their FileSpec values.  The successful result specifies
     /// the output file written (if any).
+    ///
+    /// The specified directory in which to execute the command is specified by
+    /// the input cwd parameter; if the directory for this SubProcOperation has
+    /// been explicitly overridden by calls to SubProcOperation::set_dir() (or
+    /// ChainedOpRef::set_dir()) then those take priority and this input cwd is
+    /// ignored.  This is useful for setting a default directory, but allowing a
+    /// particular operation to explicitly override the directory.
     pub fn execute(&self, cwd: &Path) -> anyhow::Result<SubProcFile>
     {
         let mut args = self.args.clone();
@@ -520,7 +527,9 @@ impl SubProcOperation {
         }
     }
 
-    // After the files are setup, this performs the actual run
+    // After the files are setup, this performs the actual run.  See the
+    // documentation for execute() above for a description of the handling of the
+    // cwd parameter.
     fn run_cmd(&self, cwd: &Path, outfile : SubProcFile, args : Vec<OsString>)
                -> anyhow::Result<SubProcFile>
     {
@@ -781,6 +790,12 @@ impl ChainedSubOps
     /// Executes all the enabled operations in this chain sequentially, updating
     /// the input file of each operation to be the output file from the previous
     /// operation.  On success, returns the number of operations executed.
+    ///
+    /// The directory parameter specifies the default directory from which the
+    /// chained operations will be performed.  Each chained operation might
+    /// operate from a separate directory if the SubProcOperation::set_dir() or
+    /// ChainedOpRef::set_dir() function has been called for this operation,
+    /// which overrides the default directory passed to this command.
     pub fn execute<T>(&self, cwd: &Option<T>) -> anyhow::Result<usize>
     where PathBuf: From<T>, T: Clone
     {

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -344,7 +344,7 @@ impl From<&Operation> for String {
     fn from(op: &Operation) -> Self {
         match op {
             Operation::Execute(cmd) =>
-                cmd.clone().into_string().unwrap_or(String::from("<command>")),
+                cmd.clone().into_string().unwrap_or_else(|_| String::from("<command>")),
             Operation::Call(_) => String::from("local-function")
         }
     }
@@ -518,7 +518,7 @@ impl SubProcOperation {
     fn run_cmd(&self, cwd: &Path, outfile : SubProcFile, args : Vec<OsString>)
                -> anyhow::Result<SubProcFile>
     {
-        let fromdir = self.in_dir.clone().unwrap_or(cwd.to_path_buf());
+        let fromdir = self.in_dir.clone().unwrap_or_else(|| cwd.to_path_buf());
         match &self.cmd {
             Operation::Execute(cmd) => {
                 match process::Command::new(&cmd)

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -246,7 +246,10 @@ impl FileSpec {
                             .collect::<Vec<String>>()
                             .join(",")
                             ;
-                        args.push(OsString::from(bc_files))
+                        *args =
+                            args.into_iter()
+                            .map(|arg| replace(needle, &bc_files.clone().into(), arg))
+                            .collect();
                     }
                 }
         }

--- a/src/bom/chainsop.rs
+++ b/src/bom/chainsop.rs
@@ -1,0 +1,872 @@
+/// This module provides functionality for running one or more sub-process
+/// operations.  Each sub-process operation is specified as the command to run,
+/// the arguments to the command, and the input and output files.
+///
+/// The input and output files can be supplied to the command in a number of
+/// ways: by replacing a pattern in one or more of the args, or by simply
+/// appending the file to the list of arguments (if both input and output files
+/// are marked this way, the input file(s) are appended first, followed by the
+/// output file.
+///
+/// There can also be a chain of operations which are performed in sequential
+/// order.  The assumption is that each subsequent operation consumes the output
+/// of the previous operation (i.e. the out_file of an operation becomes the
+/// inp_file of the next operation) and this linkage is automatically setup when
+/// executing the chain.  This is especially useful when the input files are
+/// specified as NamedFile::Temp files in which case the chain is provided with
+/// the original input file that starts the chain and the final output file that
+/// the chain should produce and it can automatically generate the intermediary
+/// files as temporary files.
+///
+/// To facilitate the generation of a chain of commands where the individual
+/// commands may or may not actually be executed as part of the final chain, each
+/// chained command can be enabled or disabled, where the latter effectively
+/// erases it from the actually executed chain, but while the chain is built the
+/// arguments can still be specified for that operation (allowing the calling
+/// code to avoid a series of conditional updates).
+///
+/// ----------------------------------------------------------------------
+/// Alternatives:
+///
+/// * subprocess crate (https://crates.io/crates/subprocess)
+///
+///     The subprocess crate allows creation of pipelines connected via
+///     stdin/stdout, but not sequences using shared input/output files.
+///
+///     In addition, chainsop provides automatic creation and management of
+///     temporary files used in the above.
+///
+///     The chainsop package provides more direct support for incrementally
+///     building the set of commands with outputs; the subprocess crate would
+///     require more discrete management and building of a Vec<Exec>.
+///
+///     The chainsop allows elements of the chain to be local functions called in
+///     the proper sequence of operations and for elements of the chain to be
+///     disabled prior to actual execution (where they are skipped).
+///
+///     The subprocess crate provides more features for handling stdout/stderr
+///     redirection, non-blocking and timed sub-process waiting, and interaction
+///     with the sub-process.
+///
+///     Summary: significant overlap in capabilities with slightly different
+///     use-case targets and features.
+///
+/// * duct (https://github.com/oconner663/duct.rs
+///
+///     Lightweight version of the subprocess crate
+///
+/// * cargo-make, devrc, rhiz, run-cli, naumann, yamis
+///
+///    Task runners, requiring an external specification of the commands and no
+///    support for chaining inputs/outputs.  These could be written on top of
+///    chainsop.
+///
+/// * steward crate (https://crates.io/crates/steward)
+///
+///    Useful for running multiple commands and allows dependency management, but
+///    not input/output chaining or incremental command building.  Does support
+///    other features like environment control and process pools.  Closer to
+///    chainsop than the task runners, but again, this could be written on top of
+///    chainsop.
+
+use std::cell::{RefCell, RefMut};
+use std::env::current_dir;
+use std::ffi::{OsString};
+use std::fmt;
+use std::path::{Path,PathBuf};
+use std::process;
+use std::rc::Rc;
+
+
+/// Designates a type of file that can be identified by name on the command line.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub enum NamedFile {
+    /// Create a temporary file; str is suffix to give temporary filename
+    Temp(String),
+
+    /// Actual filename (may or may not currently exist)
+    Actual(PathBuf),
+
+    // Multiple input files: not yet supported.  It is ostensibly better to
+    // represent them here because all input files should share the same FileSpec
+    // enum type, but multiple output files isn't really supported for chaining
+    // to the next input...
+    //
+    // Actuals(Vec<PathBuf>),
+
+    /// glob search in specified dir for all matching files
+    GlobIn(PathBuf, String),
+
+    /// allowed on initial construction, but an error for execute
+    TBD
+}
+
+impl NamedFile {
+    /// Generates the designation indicating the need for a temporary file with
+    /// the specified suffix.  If no particular suffix is needed, a blank suffix
+    /// value should be specified.
+    pub fn temp<T>(suffix: T) -> NamedFile
+    where String: From<T>
+    {
+        NamedFile::Temp(String::from(suffix))
+    }
+
+    /// Generates a reference to an actual file
+    pub fn actual<T>(fpath: T) -> NamedFile
+    where PathBuf: From<T>
+    {
+        NamedFile::Actual(PathBuf::from(fpath))
+    }
+
+    pub fn glob_in<T,U>(dpath: T, glob: U) -> NamedFile
+    where PathBuf: From<T>, String: From<U>
+    {
+        NamedFile::GlobIn(PathBuf::from(dpath), String::from(glob))
+    }
+}
+
+
+/// Determines how a file should be specified for the associated command when
+/// issuing the command at execution time.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default)]
+pub enum FileSpec {
+    /// No file is expressed or needed
+    #[default]
+    Unneeded,
+
+    /// Append the named file to the command string
+    Append(NamedFile),
+
+    /// first string is the option to emit, which will be followed by the file
+    Option(String, NamedFile),
+
+    /// replace the specified text in any argument with the named file.
+    Replace(String, NamedFile)
+
+    // ReplaceOrAppend(String, NamedFile),  // first string string is the marker (in args) to be replaced with the file specified as the second string.  If the marker never appears, fallback to Append behavior.
+
+}
+
+impl FileSpec {
+
+    // Internal function to resolve a FileSpec and insert the actual named file
+    // into the argument list.  This also returns the file; the file may be a
+    // temporary file object which will delete the file at the end of its
+    // lifetime, so the returned value should be held until the file is no longer
+    // needed.
+    fn setup_file<E>(&self, args: &mut Vec<OsString>, on_missing: E)
+                     -> anyhow::Result<SubProcFile>
+    where E: Fn() -> anyhow::Result<SubProcFile>
+    {
+        match &self {
+            FileSpec::Unneeded => (),
+            FileSpec::Append(nf) =>
+                match nf {
+                    NamedFile::TBD => return on_missing(),
+                    NamedFile::Temp(sfx) => {
+                        let tf = tempfile::Builder::new().suffix(sfx).tempfile()?;
+                        args.push(OsString::from(tf.path()));
+                        return Ok(SubProcFile::TempOutputFile(tf))
+                    }
+                    NamedFile::Actual(fpath) => {
+                        args.push(fpath.into());
+                        return Ok(SubProcFile::StaticOutputFile(fpath.clone()));
+                    }
+                    NamedFile::GlobIn(dpath, glob) => {
+                        let mut bc_glob = String::new();
+                        bc_glob.push_str(&OsString::from(dpath).into_string().unwrap());
+                        bc_glob.push_str("/");
+                        bc_glob.push_str(glob);
+                        let bc_files = glob::glob(&bc_glob)?;
+                        for bc_entry in bc_files {
+                            let bc_file = bc_entry?;
+                            args.push(OsString::from(bc_file));
+                        }
+                    }
+                }
+            FileSpec::Option(optflag, nf) =>
+                match nf {
+                    NamedFile::TBD => return on_missing(),
+                    NamedFile::Temp(sfx) => {
+                        let tf = tempfile::Builder::new().suffix(sfx).tempfile()?;
+                        args.push(OsString::from(optflag));
+                        args.push(OsString::from(tf.path()));
+                        return Ok(SubProcFile::TempOutputFile(tf))
+                    }
+                    NamedFile::Actual(fpath) => {
+                        args.push(OsString::from(optflag));
+                        args.push(fpath.into());
+                        return Ok(SubProcFile::StaticOutputFile(fpath.clone()));
+                    }
+                    NamedFile::GlobIn(dpath, glob) => {
+                        let mut bc_glob = String::new();
+                        bc_glob.push_str(&OsString::from(dpath).into_string().unwrap());
+                        bc_glob.push_str("/");
+                        bc_glob.push_str(glob);
+                        let bc_files : Vec<PathBuf> = glob::glob(&bc_glob)?
+                            .filter_map(Result::ok)
+                            .collect();
+                        let bc_files_str = bc_files.iter()
+                            .map(|x| OsString::from(x).into_string().unwrap())
+                            .collect::<Vec<String>>() ;
+                        args.push(OsString::from(optflag));
+                        args.push(OsString::from(bc_files_str.join(",")));
+                        return Ok(SubProcFile::StaticOutputFiles(bc_files));
+                    }
+                }
+            FileSpec::Replace(needle, nf) =>
+                match nf {
+                    NamedFile::TBD => return on_missing(),
+                    NamedFile::Temp(sfx) => {
+                        let tf = tempfile::Builder::new().suffix(sfx).tempfile()?;
+                        let tfs = OsString::from(tf.path());
+                        *args =
+                            args.into_iter()
+                            .map(|arg| replace(needle, &tfs, arg))
+                            .collect();
+                        return Ok(SubProcFile::TempOutputFile(tf))
+                    }
+                    NamedFile::Actual(fpath) => {
+                        *args =
+                            args.into_iter()
+                            .map(|arg| replace(needle, &fpath.into(), arg))
+                            .collect();
+                        return Ok(SubProcFile::StaticOutputFile(fpath.clone()));
+                    }
+                    NamedFile::GlobIn(dpath, glob) => {
+                        let mut bc_glob = String::new();
+                        bc_glob.push_str(&OsString::from(dpath).into_string().unwrap());
+                        bc_glob.push_str("/");
+                        bc_glob.push_str(glob);
+                        let bc_files = glob::glob(&bc_glob)?
+                            .filter_map(Result::ok)
+                            .map(|x| OsString::from(x).into_string().unwrap())
+                            .collect::<Vec<String>>()
+                            .join(",")
+                            ;
+                        args.push(OsString::from(bc_files))
+                    }
+                }
+        }
+        Ok(SubProcFile::NoOutputFile)
+    }
+
+    // Alternative to the setup_file function which instead uses the specified
+    // file instead of the existing specification, modifying the args in the
+    // appropriate manner to insert the file reference.
+    fn setup_file_override(&self,
+                           ovrf: &PathBuf,
+                           mut args: Vec<OsString>)
+                           -> Vec<OsString>
+    {
+        match &self {
+            FileSpec::Unneeded => args,
+            FileSpec::Append(_) => { args.push(ovrf.into()); args },
+            FileSpec::Option(flg, _) => {
+                args.push(OsString::from(flg));
+                args.push(ovrf.into());
+                args
+            },
+            FileSpec::Replace(pat, _) =>
+                args.into_iter()
+                .map(|arg| replace(pat, &ovrf.into(), &arg))
+                .collect()
+        }
+    }
+}
+
+
+// ----------------------------------------------------------------------
+// Single sub-process operation management
+
+/// This structure represents a single command to run as a sub-process, the
+/// command's arguments, and the input and output files for that sub-process.
+/// The structure itself is public but the fields are private
+/// (i.e. implementation specific); the impl section below defines the visible
+/// operations that can be performed on this structure.
+#[derive(Debug)]
+pub struct SubProcOperation {
+    cmd : Operation,
+    args : Vec<OsString>,
+    inp_file : FileSpec,
+    out_file : FileSpec,
+    in_dir : Option<PathBuf>,
+}
+
+enum Operation {
+    /// Name of executable to invoke in subprocess
+    Execute(OsString),
+
+    /// Local function to call instead of executing a subprocess.  The first
+    /// argument is the current working directory, the second is the argument
+    /// vector (the input and output files will be part of the argument vector as
+    /// determined by their corresponding FileSpec).
+    Call(Box<dyn Fn(&Path, Vec<OsString>) -> anyhow::Result<()>>)
+    // n.b. Would prefer this to be an FnOnce, but that breaks move semantics
+    // when trying to call it while it's a part of an enclosing Enum.
+}
+
+impl std::fmt::Debug for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result
+    {
+        match self {
+            Operation::Execute(cmd) => cmd.fmt(f),
+            Operation::Call(_) => "Local function call".fmt(f)
+        }
+    }
+}
+impl From<&Operation> for String {
+    fn from(op: &Operation) -> Self {
+        match op {
+            Operation::Execute(cmd) =>
+                cmd.clone().into_string().unwrap_or(String::from("<command>")),
+            Operation::Call(_) => String::from("local-function")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SubProcFile {
+    NoOutputFile,
+    StaticOutputFile(PathBuf),
+    StaticOutputFiles(Vec<PathBuf>),
+    TempOutputFile(tempfile::NamedTempFile),
+}
+
+#[derive(thiserror::Error,Debug)]
+pub enum SubProcError {
+
+    #[error("Sub-process {1:} file not specified for command {0:?}")]
+    ErrorMissingFile(String, String),
+
+    #[error("Error {2:?} running command {0:?} {1:?} in dir {3:?}\n{4:}")]
+    ErrorRunningCmd(String, Vec<OsString>, Option<i32>, PathBuf, String),
+
+    #[error("Error {2:?} setting up running command {0:?} {1:?} in dir {3:?}")]
+    ErrorCmdSetup(String, Vec<OsString>, std::io::Error, PathBuf)
+}
+
+impl SubProcOperation {
+
+    /// Creates a new SubProcOperation that will be capable of executing the
+    /// specified command with the corresponding input and output files.
+    pub fn new<'a, T>(cmd : &'a T,
+                      inp_file : &FileSpec,
+                      out_file : &FileSpec)
+                      -> SubProcOperation
+    where OsString: From<&'a T>
+    {
+        SubProcOperation {
+            cmd : Operation::Execute(OsString::from(cmd)),
+            args : Vec::new(),
+            inp_file : inp_file.clone(),
+            out_file : out_file.clone(),
+            in_dir : None,
+        }
+    }
+
+    /// Creates a new SubProcOperation that will call a local function instead of
+    /// executing a command in a sub-process.  This is useful for interleaving
+    /// local processing into the command chain where that local processing is
+    /// executed in proper sequence with the other commands.  The local function
+    /// is provided with the "argument list" that would have been passed on the
+    /// command-line; this argument list will contain any input or output
+    /// filenames that should be used by the function.
+    ///
+    /// A local function execution in the chain can only pass an output file to
+    /// the subsequent operation in the chain; more complex data exchange would
+    /// need to be serialized into that output file and appropriately consumed by
+    /// the next stage. This might initially seem awkward, but makes sense when
+    /// you consider that most operations are executions in subprocesses that are
+    /// in a separate address space already.
+    pub fn calling<T>(f: T) -> SubProcOperation
+    where T: Fn(&Path, Vec<OsString>) -> anyhow::Result<()> + 'static
+    {
+        SubProcOperation {
+            cmd : Operation::Call(Box::new(f)),
+            args : Vec::new(),
+            inp_file : Default::default(),
+            out_file : Default::default(),
+            in_dir : None,
+        }
+    }
+
+    /// Adds a command-line argument to use when executing the command.
+    #[inline]
+    pub fn push_arg<T>(&mut self, arg: T) -> &SubProcOperation
+    where OsString: From<T>
+    {
+        self.args.push(OsString::from(arg));
+        self
+    }
+
+    /// Sets the input file for the command, overriding any previous input file
+    /// specification.
+    #[inline]
+    pub fn set_input_file(&mut self, inp_file: &FileSpec) -> &SubProcOperation
+    {
+        self.inp_file = inp_file.clone();
+        self
+    }
+
+    /// Sets the output file for the command, overriding any previous output file
+    /// specification.
+    #[inline]
+    pub fn set_output_file(&mut self, out_file: &FileSpec) -> &SubProcOperation
+    {
+        self.out_file = out_file.clone();
+        self
+    }
+
+    /// Sets the directory from which the operation will be executed.  The caller
+    /// is responsible for ensuring any Actual FileSpec paths are valid when
+    /// operating from that directory and any Temp FileSpec files created will
+    /// still be created in the normal temporary directory location.
+    #[inline]
+    pub fn set_dir<T>(&mut self, in_dir: T) -> &SubProcOperation
+    where T: AsRef<Path>
+    {
+        self.in_dir = Some(in_dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// Executes this command in a subprocess in the specified directory.  The
+    /// input and output files will be determined and added to the command-line
+    /// as indicated by their FileSpec values.  The successful result specifies
+    /// the output file written (if any).
+    pub fn execute(&self, cwd: &Path) -> anyhow::Result<SubProcFile>
+    {
+        let mut args = self.args.clone();
+        let outfile;
+        if self.emit_output_file_first() {
+            outfile = self.out_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("output")))))?;
+            self.inp_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("input")))))?;
+        } else {
+            self.inp_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("input")))))?;
+            outfile = self.out_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("output")))))?;
+        }
+        self.run_cmd(cwd, outfile, args)
+    }
+    // Output option arguments before positional arguments because some command's
+    // parsers are limited in this way.  This function returns true if the output
+    // file should be specified before the input file; the normal order is input
+    // file and then output file (e.g. "cp inpfile outfile").
+    fn emit_output_file_first(&self) -> bool
+    {
+        if let FileSpec::Option(_, _) = self.out_file {
+            if let FileSpec::Append(_) = self.inp_file {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    // After the files are setup, this performs the actual run
+    fn run_cmd(&self, cwd: &Path, outfile : SubProcFile, args : Vec<OsString>)
+               -> anyhow::Result<SubProcFile>
+    {
+        match &self.cmd {
+            Operation::Execute(cmd) => {
+                match process::Command::new(&cmd)
+                .args(&args)
+                .current_dir(self.in_dir.as_ref().unwrap_or(&cwd.to_path_buf()))
+                .stdout(process::Stdio::piped())
+                .stderr(process::Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => {
+                    let out = child.wait_with_output()?;
+                    if !out.status.success() {
+                        return Err(anyhow::Error::new(
+                            SubProcError::ErrorRunningCmd(
+                                String::from(&self.cmd), args,
+                                out.status.code(),
+                                cwd.to_path_buf(),
+                                String::from_utf8_lossy(&out.stderr).into_owned())))
+                    }
+                }
+                Err(e) => {
+                    return Err(anyhow::Error::new(
+                        SubProcError::ErrorCmdSetup(String::from(&self.cmd),
+                                                    args, e,
+                                                    cwd.to_path_buf())))
+                }
+            }
+            }
+            Operation::Call(func) => {
+                func(cwd, args)?
+            }
+        }
+        Ok(outfile)
+    }
+
+    /// Executes this command in a subprocess in the specified directory,
+    /// overriding the input.  There might be multiple input files (e.g. with
+    /// GlobIn): the FileSpec application is repeated for each input file.  If
+    /// there are no input files, then this behaves just as the normal execute
+    /// function.
+    pub fn execute_with_inp_override(&self,
+                                     cwd: &Path,
+                                     inps: &Vec<PathBuf>)
+                                     -> anyhow::Result<SubProcFile> {
+        if inps.len() == 0 {
+            return self.execute(cwd);
+        }
+
+        let mut args = self.args.clone();
+        let mut outfile = SubProcFile::NoOutputFile;
+        if self.emit_output_file_first() {
+            outfile = self.out_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("output")))))?;
+        }
+        for inpf in inps {
+            args = self.inp_file.setup_file_override(inpf, args);
+        }
+        if !self.emit_output_file_first() {
+            outfile = self.out_file.setup_file(
+                &mut args,
+                || Err(anyhow::Error::new(
+                    SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                   String::from("output")))))?;
+        }
+        self.run_cmd(cwd, outfile, args)
+    }
+
+    // Executes this command in a subprocess in the specified directory,
+    // overriding the input *and* the output files.  If the output override is
+    // None this acts the same as execute_with_inp_override.
+    pub fn execute_with_file_overrides(&self,
+                                       cwd: &Path,
+                                       inps: &Vec<PathBuf>,
+                                       out: &Option<PathBuf>)
+                                       -> anyhow::Result<SubProcFile> {
+        match &out {
+            None => self.execute_with_inp_override(cwd, inps),
+            Some (outf) => {
+                let mut args = self.args.clone();
+                let outfile = SubProcFile::StaticOutputFile(outf.clone());
+                if self.emit_output_file_first() {
+                    args = self.out_file.setup_file_override(outf, args);
+                }
+                if inps.len() == 0 {
+                    self.inp_file.setup_file(
+                        &mut args,
+                        || Err(anyhow::Error::new(
+                            SubProcError::ErrorMissingFile(String::from(&self.cmd),
+                                                           String::from("input")))))?;
+                } else {
+                    for inpf in inps {
+                        args = self.inp_file.setup_file_override(inpf, args);
+                    }
+                }
+                if !self.emit_output_file_first() {
+                    args = self.out_file.setup_file_override(outf, args);
+                }
+                self.run_cmd(cwd, outfile, args)
+            }
+        }
+    }
+}
+
+fn replace(pat : &String, subs : &OsString, inpstr : &OsString) -> OsString
+{
+    match subs.clone().into_string() {
+        Ok(sub) => match inpstr.clone().into_string() {
+            Ok(inps) => OsString::from(inps.replace(pat, &sub)),
+            Err(orig) => orig
+        }
+        Err(_) => inpstr.clone()
+
+    }
+}
+
+// ----------------------------------------------------------------------
+/// Chained sub-process operations
+///
+/// General notes about structure organization:
+///
+///   The ChainedSubProcOperations is the core structure that contains the list
+///   of operations that should be chained together, along with the initial input
+///   file and final output file.
+///
+///   When adding an operation to ChainedSubProcOperations (via .push_op()) the
+///   return value should allow subsequent examination/manipulation of that
+///   specific operation in the chain (the ChainedOpRef struct).  To do so, and
+///   honor Rust's ownership rules, this means that the result references the
+///   core ChainedSubProcOperations via a reference counted (Rc) cell (RefCell)
+///   to maintain a single copy via the Rc but allow updates of that object via
+///   the RefCell.
+///
+///   To hide the complexity of the Rc<RefCell<ChainedSubProcOperations>> from
+///   the user, this value is wrapped in the ChainedSubOps struct.
+///
+///   User API operations are therefore primarily defined for the ChainedSubOps
+///   and ChainedOpRef structs.
+///
+///   The typical API usage:
+///
+///    let all_ops = ChainedSubOps::new()
+///    let op1 = all_ops.push_op(
+///               SubProcOperation::new("command",
+///                                     <how to specify input file to command>,
+///                                     <how to specify output file to command>))
+///    let op2 = all_ops.push_op(
+///               SubProcOperation::new("next-command",
+///                                     <how to specify input file>,
+///                                     <how to specify output file>))
+///    ...
+///    op1.push_arg("-x")
+///    op2.push_arg("-f")
+///    op2.push_arg(filename)
+///    op2.disable()
+///    ...
+///    all_ops.set_input_file_for_chain(input_filename)
+///    all_ops.set_output_file_for_chain(output_filename)
+///    match all_ops.execute() {
+///      Err(e) => ...,
+///      Ok(sts) -> ...,
+///    }
+
+/// Internal structure managing the chain of operations
+#[derive(Debug)]
+struct ChainedSubProcOperations {
+    chain : Vec<SubProcOperation>,
+    initial_inp_file : Option<PathBuf>,
+    final_out_file : Option<PathBuf>,
+    disabled : Vec<usize>
+}
+
+#[derive(Clone,Debug)]
+pub struct ChainedOpRef {
+    opidx : usize,
+    chop : Rc<RefCell<ChainedSubProcOperations>>
+}
+
+
+pub struct ChainedSubOps {
+    chops : Rc<RefCell<ChainedSubProcOperations>>
+}
+
+impl fmt::Debug for ChainedSubOps {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.chops.borrow(), f)
+    }
+}
+
+impl ChainedSubOps {
+    // The result is Rc'd so that the ChainedOpRef instances can have a
+    // reference to the target as well.
+    pub fn new() -> ChainedSubOps
+    {
+        ChainedSubOps {
+            chops :
+            Rc::new(
+                RefCell::new(
+                    ChainedSubProcOperations { chain : Vec::new(),
+                                               initial_inp_file : None,
+                                               final_out_file : None,
+                                               disabled : Vec::new()
+                    }
+                )
+            )
+        }
+    }
+}
+
+
+impl ChainedSubOps
+{
+    /// Adds a new operation to the end of the chain.  Returns a reference for
+    /// modifying that operation.
+    pub fn push_op(self: &ChainedSubOps, op: SubProcOperation) -> ChainedOpRef
+    {
+        {
+            let mut ops: RefMut<_> = self.chops.borrow_mut();
+            ops.chain.push(op);
+        }
+        ChainedOpRef { opidx : self.chops.borrow().chain.len() - 1,
+                       chop : Rc::clone(&self.chops)
+        }
+    }
+
+    /// Retrieves the name of input file providing the original input to the
+    /// entire chain.
+    #[inline]
+    pub fn inp_file_for_chain(&self, inp_file: &Option<PathBuf>) -> ()
+    {
+        let mut ops: RefMut<_> = self.chops.borrow_mut();
+        ops.initial_inp_file = inp_file.clone();
+    }
+
+    /// Sets the output file for the entire chain (i.e. the end file)
+    #[inline]
+    pub fn set_out_file_for_chain(&self, out_file: &Option<PathBuf>) -> ()
+    {
+        let mut ops: RefMut<_> = self.chops.borrow_mut();
+        ops.final_out_file = out_file.clone();
+    }
+
+    /// Gets the output file path for the end of the chain.  Returns None if the
+    /// output file is not specified or is indefinite/temporary and therefore
+    /// cannot be accessed.
+    #[inline]
+    pub fn out_file_for_chain(&self) -> Option<PathBuf>
+    {
+        self.chops.borrow().final_out_file.clone()
+    }
+
+    /// Executes all the enabled operations in this chain sequentially, updating
+    /// the input file of each operation to be the output file from the previous
+    /// operation.  On success, returns the number of operations executed.
+    pub fn execute<T>(&self, cwd: &Option<T>) -> anyhow::Result<usize>
+    where PathBuf: From<T>, T: Clone
+    {
+        let curdir = match &cwd {
+            Some(p) => PathBuf::from(p.clone()),
+            None => current_dir()?
+        };
+        let chops = self.chops.borrow();
+        // n.b. cannot Clone the chain (thus, cannot alter it), so instead build
+        // a vec of the valid indices.  Build it in reverse so the operations can
+        // simply .pop() the next index off the end.
+        let mut enabled_opidxs : Vec<usize> = chops.chain.iter()
+            .enumerate()
+            .filter(|(i,_op)| ! chops.disabled.contains(i))
+            .map(|(i,_op)| i)
+            .rev()
+            .collect();
+        execute_chain(&chops.chain, curdir.as_path(), &mut enabled_opidxs,
+                      &match &chops.initial_inp_file {
+                          Some(f) => vec![f.clone()],
+                          None => vec![]
+                      },
+                      &chops.final_out_file)
+            .map(|r| r + 1)
+    }
+}
+
+fn execute_chain(chops: &Vec<SubProcOperation>,
+                 cwd: &Path,
+                 mut op_idxs: &mut Vec<usize>,
+                 inp_files : &Vec<PathBuf>,  // usually just one, except GlobIn
+                 out_file : &Option<PathBuf>)
+                 -> anyhow::Result<usize>
+{
+    let op_idx = op_idxs.pop().unwrap();
+    let spo = &chops[op_idx];
+    let last_op = op_idxs.is_empty();
+    if last_op {
+        spo.execute_with_file_overrides(cwd, inp_files, out_file)?;
+        return Ok(1);
+    }
+
+    let outfile = spo.execute_with_inp_override(cwd, inp_files)?;
+    let nxt_inpfile = match &outfile {
+        SubProcFile::NoOutputFile => vec![],
+        SubProcFile::StaticOutputFile(f) => vec![f.clone()],
+        SubProcFile::TempOutputFile(tf) => vec![tf.path().to_path_buf()],
+        SubProcFile::StaticOutputFiles(fs) => fs.clone(),
+    };
+    let nxt = execute_chain(chops, cwd, &mut op_idxs, &nxt_inpfile, &out_file)?;
+    Ok(nxt + 1)
+}
+
+impl ChainedOpRef {
+    /// Add an argument to this operation in the chain
+    #[inline]
+    pub fn push_arg<T>(&self, arg: T) -> &ChainedOpRef
+    where OsString: From<T>
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.chain[self.opidx].args.push(OsString::from(arg));
+        }
+        self
+    }
+
+    /// Sets the default directory for execution of this operation
+    pub fn set_dir<T>(&self, tgtdir: T) -> &ChainedOpRef
+    where T: AsRef<Path>
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.chain[self.opidx].set_dir(tgtdir);
+        }
+        self
+    }
+
+    /// Enables this operation in the chain.  By default, an operation added to
+    /// the chain is automatically enabled, but it can be explicitly disabled or
+    /// enabled prior to execution.  See disable() for more information.
+    #[inline]
+    pub fn enable(&self) -> &ChainedOpRef
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.disabled.retain(|&x| x != self.opidx);
+        }
+        self
+    }
+
+    /// Disables this operation in the chain.  By default, an operation added to
+    /// the chain is automatically enabled, but it can be explicitly disabled or
+    /// enabled prior to execution.
+    /// This is useful for building a chain
+    /// consisting of all possible operations and then "removing" those that are
+    /// subsequently determined not to be needed by disabling them.
+    #[inline]
+    pub fn disable(&self) -> &ChainedOpRef
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.disabled.push(self.opidx);
+        }
+        self
+    }
+
+    /// Sets the input file specification for this operation, overriding any
+    /// previous specification.
+    pub fn set_input(&self, inp_spec : &FileSpec) -> &ChainedOpRef
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.chain[self.opidx].set_input_file(inp_spec);
+        }
+        self
+    }
+
+    /// Sets the output file specification for this operation, overriding any
+    /// previous specification.
+    pub fn set_output(&self, inp_spec : &FileSpec) -> &ChainedOpRef
+    {
+        {
+            let mut ops: RefMut<_> = self.chop.borrow_mut();
+            ops.chain[self.opidx].set_output_file(inp_spec);
+        }
+        self
+    }
+}

--- a/src/bom/extract.rs
+++ b/src/bom/extract.rs
@@ -95,7 +95,7 @@ pub fn extract_bitcode_entrypoint(extract_options : &ExtractOptions) -> anyhow::
         bc_glob.push_str(&OsString::from(tmp_dir.path()).into_string().unwrap());
         bc_glob.push_str("/*.bc");
 
-        extract_ops.execute::<String>(&None)?;
+        extract_ops.execute::<String>(&None, false)?;
         Ok(0)
     }
 }

--- a/src/bom/extract.rs
+++ b/src/bom/extract.rs
@@ -1,126 +1,98 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process::Command;
 
 use crate::bom::options::ExtractOptions;
 use crate::bom::bitcode::ELF_SECTION_NAME;
-
-#[derive(thiserror::Error,Debug)]
-pub enum ExtractError {
-    #[error("Error running command {0:} {1:?} ({2:?})")]
-    ErrorRunningCommand(String,Vec<OsString>,std::io::Error)
-}
+use crate::bom::chainsop::{ChainedSubOps, FileSpec, NamedFile, SubProcOperation};
 
 pub fn extract_bitcode_entrypoint(extract_options : &ExtractOptions) -> anyhow::Result<i32> {
     let tmp_dir = tempfile::TempDir::new()?;
-    let mut tar_path = PathBuf::new();
-    tar_path.push(tmp_dir.path());
-    tar_path.push("bitcode.tar");
 
-    // Use objcopy to extract our tar file from the target.  Note that objcopy
-    // expects to write an output object.  If not given an output file, it will
-    // try to replace the input file with the generated version by copying the
-    // input file to a temporary file (adjacent to the input file) and then
-    // reading that temporary file to rewriting the input file with the output
-    // data.
-    //
-    // This is not necessarily a problem for the use of objcopy during the
-    // generate-bitcode phase, but extraction may be performed from installed
-    // targets where the current user does not have permissions to create a
-    // temporary file adjacent to the installed target.
-    //
-    // The most obvious solution is to supply /dev/null as the output file: then
-    // the input file is not copied to an adjacent location and the objcopy can
-    // run as needed.  This works... except for when the input file is an archive
-    // (a.k.a static library file, as in libxyz.a).  When the input file is an
-    // archive file, then objcopy appears to create a temporary output file for
-    // each member of the archive and then re-combine those into the output
-    // archive file.  The problem is that the temporary output files are adjacent
-    // to the provided output file, thus when /dev/null is provided as the output
-    // file, objcopy with an archive input will try to write to /dev/{tempfile},
-    // which fails.
-    //
-    // Thus the more robust solution is to specify the output file in a temporary
-    // directory, and there is already a convenient temporary directory created
-    // above to hold the output llvm bitcode tar file.
-    let mut objcopy_args = Vec::new();
-    objcopy_args.push(OsString::from("--dump-section"));
-    let ok_tar_name = OsString::from(tar_path).into_string().unwrap();
-    objcopy_args.push(OsString::from(format!("{}={}", ELF_SECTION_NAME, ok_tar_name)));
+    // Create a sub-context to ensure the tmp_dir remains during the entirety of
+    // the enclosed operations...
+    {
+        // Name of the tar file we will extract from the input file's ELF
+        // section.
+        let mut tar_path = PathBuf::new();
+        tar_path.push(tmp_dir.path());
+        tar_path.push("bitcode.tar");
 
-    objcopy_args.push(OsString::from(&extract_options.input));
+        let extract_ops = ChainedSubOps::new();
+        extract_ops.set_out_file_for_chain(&Some(extract_options.output.clone()));
 
-    let mut objres = PathBuf::new();
-    objres.push(tmp_dir.path());
-    objres.push("discard{output-file}");
-    objcopy_args.push(OsString::from(objres));
+        // Use objcopy to extract our tar file from the target.  Note that
+        // objcopy expects to write an output object.  If not given an output
+        // file, it will try to replace the input file with the generated version
+        // by copying the input file to a temporary file (adjacent to the input
+        // file) and then reading that temporary file to rewriting the input file
+        // with the output data.
+        //
+        // This is not necessarily a problem for the use of objcopy during the
+        // generate-bitcode phase, but extraction may be performed from installed
+        // targets where the current user does not have permissions to create a
+        // temporary file adjacent to the installed target.
+        //
+        // The most obvious solution is to supply /dev/null as the output file:
+        // then the input file is not copied to an adjacent location and the
+        // objcopy can run as needed.  This works... except for when the input
+        // file is an archive (a.k.a static library file, as in libxyz.a).  When
+        // the input file is an archive file, then objcopy appears to create a
+        // temporary output file for each member of the archive and then
+        // re-combine those into the output archive file.  The problem is that
+        // the temporary output files are adjacent to the provided output file,
+        // thus when /dev/null is provided as the output file, objcopy with an
+        // archive input will try to write to /dev/{tempfile}, which fails.
+        //
+        // Thus the more robust solution is to specify the (ignored) output file
+        // in the standard temporary directory so that objcopy-created files next
+        // to it are in a valid temporary location.
+        let objcopy = extract_ops.push_op(
+            SubProcOperation::new(
+                &"objcopy",
+                &FileSpec::Append(NamedFile::actual(&extract_options.input)),
+                &FileSpec::Append(NamedFile::temp(".o"))));
+        objcopy.push_arg("--dump-section");
 
-    match Command::new("objcopy").args(&objcopy_args).spawn() {
-        Err(msg) => {
-            return Err(anyhow::Error::new(ExtractError::ErrorRunningCommand(String::from("objcopy"), objcopy_args, msg)));
-        }
-        Ok(mut child) => {
-            match child.wait() {
-                Err(msg) => {
-                    return Err(anyhow::Error::new(ExtractError::ErrorRunningCommand(String::from("objcopy"), Vec::new() /*objcopy_args*/, msg)));
-                }
-                Ok(sts) => {
-                    if !sts.success() {
-                        match sts.code() {
-                            Some(rc) => { return Ok(rc) }
-                            None => { return Ok(-1) }
-                        }
-                    }
-                }
-            }
-        }
+        let ok_tar_name = OsString::from(&tar_path).into_string().unwrap();
+        objcopy.push_arg(format!("{}={}", ELF_SECTION_NAME, ok_tar_name));
+
+        // The tar file containing all of our bitcode is now in
+        // /tmp/{random}/bitcode.tar
+        //
+        // We can extract it in that directory.  Note that we need to use tar -i
+        // because we concatenated a number of tar files together.
+        //
+        // NOTE: Ideally, we would be able to use the tar library for this
+        // instead of calling out to tar.
+        let tar = extract_ops.push_op(
+            SubProcOperation::new(
+                &"tar",
+                // if an output file was specified, the chained ops would
+                // override this with the output file of the objcopy operation;
+                // in this case, we are not using the actual objcopy output file
+                // but instead the tarfile create as a side-effect via the
+                // --dump-section, so declare no input file and explicitly add
+                // the tarfile via a push_arg below
+                &FileSpec::Unneeded,
+                &FileSpec::Unneeded));  // tar has no output file spec.
+        tar.push_arg("xif");
+        tar.push_arg(&tar_path);
+        tar.set_dir(&tmp_dir);
+
+        // Now all the files contained in the extracted bitcode.tar should be
+        // linked together to create the final bitcode file.
+
+        extract_ops.push_op(
+            SubProcOperation::new(
+                &"llvm-link",
+                &FileSpec::Append(NamedFile::glob_in(tmp_dir.path(), "*.bc")),
+                &FileSpec::Option(String::from("-o"), NamedFile::TBD)));
+
+        let mut bc_glob = String::new();
+        bc_glob.push_str(&OsString::from(tmp_dir.path()).into_string().unwrap());
+        bc_glob.push_str("/*.bc");
+
+        extract_ops.execute::<String>(&None)?;
+        Ok(0)
     }
-
-    // The tar file containing all of our bitcode is now in /tmp/{random}/bitcode.tar
-    //
-    // We can extract it in that directory.  Note that we need to use tar -i because we
-    // concatenated a number of tar files together.
-    //
-    // NOTE: Ideally, we would be able to use the tar library for this instead
-    // of calling out to tar.
-    let mut tar_args = Vec::new();
-    tar_args.push(OsString::from("xif"));
-    tar_args.push(OsString::from(ok_tar_name));
-    match Command::new("tar").args(&tar_args).current_dir(&tmp_dir).spawn() {
-        Err(msg) => {
-            return Err(anyhow::Error::new(ExtractError::ErrorRunningCommand(String::from("tar"), tar_args, msg)));
-        }
-        Ok(mut child) => {
-            let _rc = child.wait();
-        }
-    }
-
-    // Now all the files contained in the extracted bitcode.tar should be linked together
-    // to create the final bitcode file.
-
-    let mut llvm_link_args = Vec::new();
-    llvm_link_args.push(OsString::from("-o"));
-    llvm_link_args.push(OsString::from(&extract_options.output));
-
-    let mut bc_glob = String::new();
-    bc_glob.push_str(&OsString::from(tmp_dir.path()).into_string().unwrap());
-    bc_glob.push_str("/*.bc");
-    let bc_files = glob::glob(&bc_glob)?;
-    for bc_entry in bc_files {
-        let bc_file = bc_entry?;
-        llvm_link_args.push(OsString::from(bc_file));
-    }
-
-    let llvm_link = OsString::from(extract_options.llvm_link_path.as_ref().unwrap_or(&String::from("llvm-link")));
-    match Command::new(&llvm_link).args(&llvm_link_args).spawn() {
-        Err(msg) => {
-            let llvm_link_str = llvm_link.into_string().unwrap();
-            return Err(anyhow::Error::new(ExtractError::ErrorRunningCommand(llvm_link_str, llvm_link_args, msg)));
-        }
-        Ok(mut child) => {
-            let _rc = child.wait();
-        }
-    }
-
-    Ok(0)
 }

--- a/src/bom/extract.rs
+++ b/src/bom/extract.rs
@@ -82,9 +82,12 @@ pub fn extract_bitcode_entrypoint(extract_options : &ExtractOptions) -> anyhow::
         // Now all the files contained in the extracted bitcode.tar should be
         // linked together to create the final bitcode file.
 
+        let llvm_link = OsString::from(extract_options.llvm_link_path
+                                       .as_ref()
+                                       .unwrap_or(&String::from("llvm-link")));
         extract_ops.push_op(
             SubProcOperation::new(
-                &"llvm-link",
+                &llvm_link,
                 &FileSpec::Append(NamedFile::glob_in(tmp_dir.path(), "*.bc")),
                 &FileSpec::Option(String::from("-o"), NamedFile::TBD)));
 

--- a/src/bom/extract.rs
+++ b/src/bom/extract.rs
@@ -95,7 +95,7 @@ pub fn extract_bitcode_entrypoint(extract_options : &ExtractOptions) -> anyhow::
         bc_glob.push_str(&OsString::from(tmp_dir.path()).into_string().unwrap());
         bc_glob.push_str("/*.bc");
 
-        extract_ops.execute::<String>(&None, false)?;
+        extract_ops.execute::<String>(&None, extract_options.verbose)?;
         Ok(0)
     }
 }

--- a/src/bom/mod.rs
+++ b/src/bom/mod.rs
@@ -10,3 +10,4 @@ pub mod deptree;
 pub mod extract;
 pub mod proc_read;
 pub mod clang_support;
+pub mod chainsop;

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -26,7 +26,9 @@ pub struct ExtractOptions {
     #[structopt(short="o", long="output", help="The file to save the resulting bitcode file to")]
     pub output : PathBuf,
     #[structopt(long="llvm-link-path", help="The path to the llvm-link tool (possibly version suffixed)")]
-    pub llvm_link_path : Option<String>
+    pub llvm_link_path : Option<String>,
+    #[structopt(short="v", long="verbose", help="Generate verbose output")]
+    pub verbose : bool,
 }
 
 #[derive(Debug,StructOpt)]

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -33,8 +33,6 @@ pub struct ExtractOptions {
 pub struct BitcodeOptions {
     #[structopt(long="clang", help="Name of the clang binary to use to generate bitcode (default: `clang`)")]
     pub clang_path : Option<PathBuf>,
-    #[structopt(short="b", long="bc-out", help="Directory to place LLVM bitcode (bc) output data.  The default is to place it next to the object file, but it must be accessible by a subsequent Extract operation and some build tools build in a temporary directory that is disposed of at the end of the build (e.g. CMake) ")]
-    pub bcout_path : Option<PathBuf>,
     #[structopt(short="v", long="verbose", help="Generate verbose output")]
     pub verbose : bool,
     #[structopt(long="suppress-automatic-debug", help="Prevent `build-bom` from automatically injecting flags to generate debug information in bitcode files")]

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -208,7 +208,10 @@ fn test_zlib() -> anyhow::Result<()> {
     let mut bc_path = std::path::PathBuf::new();
     bc_path.push("libz.so.1.2.11.bc");
     let bc_path2 = bc_path.clone();
-    let extract_opts = ExtractOptions { input: so_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: so_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: true };
     extract_bitcode(extract_opts)?;
     assert!(bc_path2.exists());
     Ok(())
@@ -256,7 +259,10 @@ fn test_no_compile_only() -> anyhow::Result<()> {
     let bc_path2 = bc_path.clone();
     eprintln!("## extract bitcode from {:?} to {:?} using llvm-link at {:?}",
               exe_path, bc_path, user_llvm_link_cmd());
-    let extract_opts = ExtractOptions { input: exe_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: exe_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: true };
     extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");
     assert!(bc_path2.exists());
@@ -310,7 +316,10 @@ fn test_blddir() -> anyhow::Result<()> {
     let bc_path2 = bc_path.clone();
     eprintln!("## extract bitcode from {:?} to {:?} using llvm-link at {:?}",
               exe_path, bc_path, user_llvm_link_cmd());
-    let extract_opts = ExtractOptions { input: exe_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: exe_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: true };
     extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");
     assert!(bc_path2.exists());

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -244,7 +244,7 @@ fn test_no_compile_only() -> anyhow::Result<()> {
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
-                                    verbose: false,
+                                    verbose: true,
                                     strict: false,
                                     command: cmd_opts,
                                     any_fail: true };

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -192,7 +192,6 @@ fn test_zlib() -> anyhow::Result<()> {
 
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: user_clang_cmd(),
-                                    bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
@@ -240,7 +239,6 @@ fn test_no_compile_only() -> anyhow::Result<()> {
     eprintln!("## build-bom generate bitcode via make and clang at {:?}", user_clang_cmd());
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: user_clang_cmd(),
-                                    bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
@@ -292,7 +290,6 @@ fn test_blddir() -> anyhow::Result<()> {
     eprintln!("## build-bom generate bitcode via make and clang at {:?}", user_clang_cmd());
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: user_clang_cmd(),
-                                    bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),


### PR DESCRIPTION
The build-bom functionality largely consists of issuing a sequence of commands as
sub-processes at key points in the processing.  When running the sequence of
operations, the output of one operation is usually the input of the subsequent
operation; sometimes temporary files are needed for these interspersed outputs.

This extracts the functionality of managing subprocess execution, temporary file
creation, and input-to-output chaining into the chainops module.  This simplifies
the mainline code and should facilitate future modifications of the chained
sequence of operations.

There are some small changes in the locations that various files are generated in; it is possible that this might need adjustment in the future to address the impact of these changes, but at present all tests pass and all functionality appears to be operating as desired.

This PR is an internal refactoring, so feel free to request changes or even reject it if you do not think it is the right approach; I'm working on some changes that will add more operations to the chains, and this will make it easier for me to do so, but it's certainly not required to effect those changes.