### PR TITLE
Add verbose flag to extract-bitcode and make two levels of verbosity.

### DIFF
--- a/src/bom/extract.rs
+++ b/src/bom/extract.rs
@@ -29,6 +29,10 @@ pub fn extract_bitcode_entrypoint(extract_options : &ExtractOptions) -> anyhow::
 
 pub fn do_bitcode_extraction(extract_options : &ExtractOptions,
                              tmp_path : &Path) -> anyhow::Result<i32> {
+    if ! extract_options.verbose.is_empty() {
+        println!("#=> Extracting bitcode from {:?}", extract_options.input);
+    }
+
     let mut tar_path = PathBuf::new();
     tar_path.push(tmp_path);
     tar_path.push("bitcode.tar");
@@ -124,6 +128,9 @@ pub fn do_bitcode_extraction(extract_options : &ExtractOptions,
     let bc_files = glob::glob(&bc_glob)?;
     for bc_entry in bc_files {
         let bc_file = bc_entry?;
+        if extract_options.verbose.len() > 1 {
+            println!("#: bitcode file: {:?}", bc_file.file_name().unwrap());
+        }
         llvm_link_args.push(OsString::from(bc_file));
     }
 

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -26,7 +26,9 @@ pub struct ExtractOptions {
     #[structopt(short="o", long="output", help="The file to save the resulting bitcode file to")]
     pub output : PathBuf,
     #[structopt(long="llvm-link-path", help="The path to the llvm-link tool (possibly version suffixed)")]
-    pub llvm_link_path : Option<String>
+    pub llvm_link_path : Option<String>,
+    #[structopt(short="v", long="verbose", help="Generate verbose output.  Twice for additional verbosity.")]
+    pub verbose : Vec<bool>,
 }
 
 #[derive(Debug,StructOpt)]
@@ -35,8 +37,8 @@ pub struct BitcodeOptions {
     pub clang_path : Option<PathBuf>,
     #[structopt(short="b", long="bc-out", help="Directory to place LLVM bitcode (bc) output data.  The default is to place it next to the object file, but it must be accessible by a subsequent Extract operation and some build tools build in a temporary directory that is disposed of at the end of the build (e.g. CMake) ")]
     pub bcout_path : Option<PathBuf>,
-    #[structopt(short="v", long="verbose", help="Generate verbose output")]
-    pub verbose : bool,
+    #[structopt(short="v", long="verbose", help="Generate verbose output. Twice for additional verbosity.")]
+    pub verbose : Vec<bool>,
     #[structopt(long="suppress-automatic-debug", help="Prevent `build-bom` from automatically injecting flags to generate debug information in bitcode files")]
     pub suppress_automatic_debug : bool,
     #[structopt(long="inject-argument", help="Have `build-bom` inject the given argument into the argument list when generating bitcode")]

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -197,7 +197,7 @@ fn test_zlib() -> anyhow::Result<()> {
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
-                                    verbose: false,
+                                    verbose: vec![true, true],
                                     strict: false,
                                     command: cmd_opts,
                                     any_fail: false };
@@ -210,7 +210,10 @@ fn test_zlib() -> anyhow::Result<()> {
     let mut bc_path = std::path::PathBuf::new();
     bc_path.push(format!("libz.so.{}.bc", zlib_version));
     let bc_path2 = bc_path.clone();
-    let extract_opts = ExtractOptions { input: so_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: so_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: vec![true, true]};
     extract_bitcode(extract_opts)?;
     assert!(bc_path2.exists());
     Ok(())
@@ -245,7 +248,7 @@ fn test_no_compile_only() -> anyhow::Result<()> {
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
-                                    verbose: false,
+                                    verbose: vec![],
                                     strict: false,
                                     command: cmd_opts,
                                     any_fail: true };
@@ -259,7 +262,10 @@ fn test_no_compile_only() -> anyhow::Result<()> {
     let bc_path2 = bc_path.clone();
     eprintln!("## extract bitcode from {:?} to {:?} using llvm-link at {:?}",
               exe_path, bc_path, user_llvm_link_cmd());
-    let extract_opts = ExtractOptions { input: exe_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: exe_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: vec![] };
     extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");
     assert!(bc_path2.exists());
@@ -297,7 +303,7 @@ fn test_blddir() -> anyhow::Result<()> {
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
                                     remove_arguments: Vec::new(),
-                                    verbose: true,
+                                    verbose: vec![true],
                                     strict: true,
                                     // preproc_native: true,
                                     command: cmd_opts,
@@ -314,7 +320,10 @@ fn test_blddir() -> anyhow::Result<()> {
     let bc_path2 = bc_path.clone();
     eprintln!("## extract bitcode from {:?} to {:?} using llvm-link at {:?}",
               exe_path, bc_path, user_llvm_link_cmd());
-    let extract_opts = ExtractOptions { input: exe_path, output: bc_path, llvm_link_path: user_llvm_link_cmd() };
+    let extract_opts = ExtractOptions { input: exe_path,
+                                        output: bc_path,
+                                        llvm_link_path: user_llvm_link_cmd(),
+                                        verbose: vec![true] };
     extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");
     assert!(bc_path2.exists());


### PR DESCRIPTION
Adds diagnostic output on-demand to assist in debugging failure cases.