### PR TITLE
Add user objcopy specification and general executable handling

### DIFF
--- a/src/bom/executables.rs
+++ b/src/bom/executables.rs
@@ -1,0 +1,35 @@
+use chainsop::{Executable, ExeFileSpec, SubProcOperation};
+use std::path::PathBuf;
+
+lazy_static::lazy_static! {
+
+    pub static ref CLANG_LLVM : Executable =
+        Executable::new("clang",
+                        ExeFileSpec::Append,
+                        ExeFileSpec::option("-o"))
+        .push_arg("-emit-llvm")
+        .push_arg("-c");
+
+    pub static ref TAR_EXTRACT : Executable =
+        Executable::new("tar",
+                        ExeFileSpec::option("-f"),
+                        ExeFileSpec::NoFileUsed)
+        .push_arg("xi");
+
+    pub static ref LLVM_LINK : Executable =
+        Executable::new("llvm-link",
+                        ExeFileSpec::Append,
+                        ExeFileSpec::option("-o"));
+
+}
+
+
+/// Returns a [chainsop::SubProcOperation] for the specified executable, with a
+/// possible override for the name of the executable.
+pub fn run(exe: &Executable, userspec: &Option<PathBuf>) -> SubProcOperation {
+    let e = match userspec {
+        Some(p) => exe.set_exe(p),
+        None => exe.clone(),
+    };
+    SubProcOperation::new(&e)
+}

--- a/src/bom/mod.rs
+++ b/src/bom/mod.rs
@@ -7,6 +7,7 @@ pub mod versioning;
 pub mod bitcode;
 pub mod loader;
 pub mod deptree;
+pub mod executables;
 pub mod extract;
 pub mod proc_read;
 pub mod clang_support;

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -29,7 +29,9 @@ pub struct ExtractOptions {
     #[structopt(short="o", long="output", help="The file to save the resulting bitcode file to")]
     pub output : PathBuf,
     #[structopt(long="llvm-link-path", help="The path to the llvm-link tool (possibly version suffixed)")]
-    pub llvm_link_path : Option<String>,
+    pub llvm_link_path : Option<PathBuf>,
+    #[structopt(long="objcopy-path", help="The path to the objcopy tool (possibly version suffixed)")]
+    pub objcopy_path : Option<PathBuf>,
     #[structopt(short="v", long="verbose", help="Generate verbose output.  Twice for additional verbosity.")]
     pub verbose : Vec<bool>,
 }
@@ -38,6 +40,8 @@ pub struct ExtractOptions {
 pub struct BitcodeOptions {
     #[structopt(long="clang", help="Name of the clang binary to use to generate bitcode (default: `clang`)")]
     pub clang_path : Option<PathBuf>,
+    #[structopt(long="objcopy-path", help="The path to the objcopy tool (possibly version suffixed)")]
+    pub objcopy_path : Option<PathBuf>,
     #[structopt(short="b", long="bc-out", help="Directory to place LLVM bitcode (bc) output data.  The default is to place it next to the object file, but it must be accessible by a subsequent Extract operation and some build tools build in a temporary directory that is disposed of at the end of the build (e.g. CMake) ")]
     pub bcout_path : Option<PathBuf>,
     #[structopt(short="v", long="verbose", help="Generate verbose output. Twice for additional verbosity.")]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,14 +9,14 @@ pub static SOURCE_DIR: &'static str = "tests/sources";
 //
 // If the user did not provide one, just return None, which is interpreted by build-bom as 'clang'
 pub fn user_clang_cmd() -> Option<PathBuf> {
-    std::env::var("CLANG").map(|s| { let mut p = std::path::PathBuf::new(); p.push(s); p }).ok()
+    std::env::var("CLANG").ok().map(PathBuf::from)
 }
 
 // Get the user-provided llvm-link command (via the LLVM_LINK environment variable), if any
 //
 // If the user did not provide one, return None, which build-bom interprets as 'llvm-link'
-pub fn user_llvm_link_cmd() -> Option<String> {
-    std::env::var("LLVM_LINK").ok()
+pub fn user_llvm_link_cmd() -> Option<PathBuf> {
+    std::env::var("LLVM_LINK").ok().map(PathBuf::from)
 }
 
 // Get the user-provided llvm-dis command (via the LLVM_DIS environment variable), if any

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -160,6 +160,7 @@ fn test_no_compile_only() -> anyhow::Result<()> {
               common::user_clang_cmd());
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: common::user_clang_cmd(),
+                                    objcopy_path: None,
                                     bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
@@ -181,6 +182,7 @@ fn test_no_compile_only() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: exe_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![] };
     common::extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");
@@ -217,6 +219,7 @@ fn test_blddir() -> anyhow::Result<()> {
               common::user_clang_cmd());
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: common::user_clang_cmd(),
+                                    objcopy_path: None,
                                     bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
@@ -241,6 +244,7 @@ fn test_blddir() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: exe_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![true] };
     common::extract_bitcode(extract_opts)?;
     eprintln!("## bitcode extracted");

--- a/tests/test_zlib.rs
+++ b/tests/test_zlib.rs
@@ -71,6 +71,7 @@ fn zlib_do_build() -> anyhow::Result<(TempDir, String, PathBuf)> {
 
     let cmd_opts = vec![String::from("make")];
     let gen_opts = BitcodeOptions { clang_path: common::user_clang_cmd(),
+                                    objcopy_path: None,
                                     bcout_path: None,
                                     suppress_automatic_debug: false,
                                     inject_arguments: Vec::new(),
@@ -112,6 +113,7 @@ fn test_zlib_sharedlib() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: so_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![true, true]};
     common::extract_bitcode(extract_opts)?;
 
@@ -141,6 +143,7 @@ fn test_zlib_staticlib() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: lib_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![true, true]};
     common::extract_bitcode(extract_opts)?;
 
@@ -184,6 +187,7 @@ fn test_zlib_exe_static() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: exe_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![true, true]};
     common::extract_bitcode(extract_opts)?;
 
@@ -218,6 +222,7 @@ fn test_zlib_exe_sharedlib() -> anyhow::Result<()> {
     let extract_opts = ExtractOptions { input: exe_path,
                                         output: bc_path,
                                         llvm_link_path: common::user_llvm_link_cmd(),
+                                        objcopy_path: None,
                                         verbose: vec![true, true]};
     common::extract_bitcode(extract_opts)?;
 
@@ -266,6 +271,7 @@ fn test_zlib_exe_modified() -> anyhow::Result<()> {
         // via build-bom to ensure it is up-to-date before making any changes.
         let cmd_opts = vec![String::from("make")];
         let gen_opts = BitcodeOptions { clang_path: common::user_clang_cmd(),
+                                        objcopy_path: None,
                                         bcout_path: None,
                                         suppress_automatic_debug: false,
                                         inject_arguments: Vec::new(),
@@ -303,6 +309,7 @@ fn test_zlib_exe_modified() -> anyhow::Result<()> {
         let extract_opts = ExtractOptions { input: exe_path,
                                             output: bc_path,
                                             llvm_link_path: common::user_llvm_link_cmd(),
+                                            objcopy_path: None,
                                             verbose: vec![true, true]};
         common::extract_bitcode(extract_opts)?;
 


### PR DESCRIPTION
This is especially useful when build-bom is being used with a cross-compilation toolset, and thus the target ELF must be modified using the cross-compilation objcopy rather than the native objcopy.

This obsoletes #50.