### PR TITLE
Add -E to use native (original) compiler preprocessing before clang bitcode generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chainsop"
 version = "0.1.0"
-source = "git+https://github.com/kquick/chainsop.git#bbc0f1a2cc3a49872bc4ddff3c86492ce157810b"
+source = "git+https://github.com/kquick/chainsop.git#48402c83af507f3613c69a531cf14ff3f7d73e58"
 dependencies = [
  "anyhow",
  "filesprep_derive",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "filesprep_derive"
 version = "0.1.0"
-source = "git+https://github.com/kquick/chainsop.git#bbc0f1a2cc3a49872bc4ddff3c86492ce157810b"
+source = "git+https://github.com/kquick/chainsop.git#48402c83af507f3613c69a531cf14ff3f7d73e58"
 dependencies = [
  "quote",
  "syn 1.0.74",

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -285,13 +285,12 @@ fn build_bitcode_arguments(chan : &mut mpsc::Sender<Option<Event>>,
     //
     // The above is perfectly acceptable C, but if compile as C++ it yields:
     // error: ISO C++11 does not allow conversion from string literal to 'char*'.
-    let is_c_plusplus = orig_args.iter().find(
-        |&arg| arg.to_str().map(|a| !a.starts_with("-") &&
-                                (a.ends_with(".cc") ||
-                                 a.ends_with(".cpp")))
-            .unwrap_or_else(|| false))
-        .is_some();
-    let file_ext = if is_c_plusplus { ".cc" } else { ".c" };
+    //
+    // Re use of [0] below: If there are multiple input file (candidates)
+    // detected on the line, it is probably safe to just use the first since they
+    // all appeared together originally; all compilation commands must have at
+    // least one input file.
+    let file_ext = clang_support::input_language(&orig_args)[0].file_ext();
 
     // If the native compiler is used for preprocessing, it will write to a
     // temporary output file that is subsequently consumed by clang to generate

--- a/src/bom/clang_support.rs
+++ b/src/bom/clang_support.rs
@@ -314,3 +314,24 @@ pub fn is_blacklisted_clang_argument(strict_bc: bool, a : &OsStr) -> bool {
         }
     }
 }
+
+// GCC and clang have internal directives (from system-level include
+// files) for handling low-level things like alloc/dealloc resource
+// management, atomic operations, etc.  If the native compiler is GCC,
+// some of these directives will cause a failure on the clang bitcode
+// generation path if they are still present.  Since the bitcode is being
+// generated on a parallel effort and it is not being used for the final
+// executable, these internal directives can be nullified to get valid
+// bitcode with a minimal loss of information in that bitcode.
+pub static CLANG_PREPROC_DEFINES : &'static [&str] =
+    &[
+        "-D__malloc__(X,Y)=",
+        "-D__atomic_store(X,Y,Z)=",
+        "-D__atomic_fetch_add(X,Y,Z)=0",
+        "-D__atomic_fetch_sub(X,Y,Z)=0",
+        "-D__atomic_fetch_and(X,Y,Z)=0",
+        "-D__atomic_fetch_or(X,Y,Z)=0",
+        "-D__atomic_compare_exchange(A,B,C,D,E,F)=0",
+        "-D__atomic_exchange(A,B,C,D)=0",
+        "-D__atomic_load(A,B,C)=0",
+    ];

--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -72,6 +72,9 @@ pub struct BitcodeOptions {
     /// Remove clang arguments matching the given regular expression when generating bitcode
     #[arg(long="remove-argument")]
     pub remove_arguments : Vec<Regex>,
+    /// Pre-process with native compiler before generating bitcode.  This can be helpful for customized native compilers or cross-compilation.
+    #[arg(long="preproc-native", short='E')]
+    pub preproc_native : bool,
     /// Directory to place LLVM bitcode (bc) output data.
     ///
     /// The default is to place it next to the object file, but it must be

--- a/tests/test_bom.rs
+++ b/tests/test_bom.rs
@@ -168,6 +168,7 @@ fn test_no_compile_only() -> anyhow::Result<()> {
                                     remove_arguments: Vec::new(),
                                     verbose: 0,
                                     strict: false,
+                                    preproc_native: false,
                                     command: cmd_opts,
                                     any_fail: true };
     common::gen_bitcode(gen_opts)?;
@@ -224,11 +225,26 @@ fn test_blddir() -> anyhow::Result<()> {
                                     objcopy_path: None,
                                     bcout_path: None,
                                     suppress_automatic_debug: false,
-                                    inject_arguments: Vec::new(),
+                                    inject_arguments: vec!(
+                                        [
+                                            // Strict is true, as is
+                                            // preproc_native, so make will
+                                            // invoke gcc which will be used for
+                                            // the preprocessing stage, which
+                                            // generates some definitions not
+                                            // valid for clang.  When not strict,
+                                            // build-bom disables these
+                                            // automatically, but in strict mode,
+                                            // the argument injection is needed.
+                                            "-D__malloc__(X,Y)=",
+                                        ]
+                                            .iter()
+                                            .map(|s| String::from(*s))
+                                            .collect()),
                                     remove_arguments: Vec::new(),
                                     verbose: 1,
                                     strict: true,
-                                    // preproc_native: true,
+                                    preproc_native: true,
                                     command: cmd_opts,
                                     any_fail : true };
     common::gen_bitcode(gen_opts)?;

--- a/tests/test_zlib.rs
+++ b/tests/test_zlib.rs
@@ -78,6 +78,7 @@ fn zlib_do_build() -> anyhow::Result<(TempDir, String, PathBuf)> {
                                     remove_arguments: Vec::new(),
                                     verbose: 1,
                                     strict: false,
+                                    preproc_native: false,
                                     command: cmd_opts,
                                     any_fail: false };
     // n.b. any_fail must be false because zlib runs autoconf/configure and the
@@ -283,6 +284,7 @@ fn test_zlib_exe_modified() -> anyhow::Result<()> {
                                         remove_arguments: Vec::new(),
                                         verbose: 2,
                                         strict: false,
+                                        preproc_native: true,
                                         command: cmd_opts,
                                         any_fail: false };
         {


### PR DESCRIPTION
When using customized compilers (e.g. RTEMS gcc), the target compiler may have various include files and associated definitions that are not compatible with clang (e.g. the modifications are behind an `#ifdef __gcc__` barrier for no apparent reason).  This modification provides a `-E` flag which tells `build-bom` to use the "native" compiler to pre-process the input into a .c or .cc file before invoking clang on that result to obtain LLVM bitcode.
