### PR TITLE
Better help for inject-argument option

### DIFF
--- a/src/bom/options.rs
+++ b/src/bom/options.rs
@@ -66,7 +66,7 @@ pub struct BitcodeOptions {
     /// information in bitcode files
     #[arg(long="suppress-automatic-debug")]
     pub suppress_automatic_debug : bool,
-    /// Inject the given argument into the clang argument list when generating bitcode
+    /// Inject the given argument into the clang argument list when generating bitcode (e.g. --inject-argument=-march=i386)
     #[arg(long="inject-argument")]
     pub inject_arguments : Vec<String>,
     /// Remove clang arguments matching the given regular expression when generating bitcode


### PR DESCRIPTION
This is useful because the actual help output shown is:

```
      --inject-argument <INJECT_ARGUMENTS>
          Inject the given argument into the clang argument list when generating bitcode
```

but when the user attempts to use it in that fashion, build-bom tries to interpret the injected argument itself, or if quotes are used, the quotes are persisted, escaped to the clang invocation, which is invalid.  Using the `=` instead of the space is the  way to avoid these problems, but the default help output from the `clap` library does not display that format.