### PR TITLE
Downgrade report of failed "other" command from error to warning

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -808,7 +808,7 @@ fn collect_events(chan : mpsc::Receiver<Option<Event>>) -> SummaryStats {
                     }
                     Event::BuildFailureUnknownEffect(cmd, exit_code) => {
                         summary.build_failures_unknown_effect += 1;
-                        error!("Failed compile command may affect bitcode coverage '{:?} {:?} = {}'", cmd.bin, cmd.args, exit_code);
+                        warn!("Failed build command may affect bitcode coverage '{:?} {:?} = {}'", cmd.bin, cmd.args, exit_code);
                     }
                     Event::SkippingAssembleOnlyCommand(cmd) => {
                         summary.skipping_assemble_only += 1;


### PR DESCRIPTION
The original message also erroneously indicates this was a compile command, but this error is only associated with non-compile commands executed in the ptrace'd child.