### PR TITLE
The -target command-line argument takes a value.

### DIFF
--- a/src/bom/clang_support.rs
+++ b/src/bom/clang_support.rs
@@ -177,7 +177,8 @@ static FOLLOWING_ARG_OPTIONS : &'static [&str] =
       r"^-rpath$",   // unique to clang
       r"^-current_version$",
       r"^-compatibility_version$",
-      r"^-dumpbase$"
+      r"^-dumpbase$",
+      r"^-target$"
     ];
 
 lazy_static::lazy_static! {


### PR DESCRIPTION
The `-target` argument is not valid for gcc, but it is for clang, and sometimes appears as:

```
$ clang ... -target x86_64-linux ...
```

This adds the notation that the `-target` argument has an accompanying value so that build-bom interprets the word following this argument correctly.