### PR TITLE
Fix bitcode operations for lack of an explicit output file.

### DIFF
--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -451,6 +451,8 @@ fn build_bitcode_arguments(chan : &mut mpsc::Sender<Option<Event>>,
                     let mut target_path = PathBuf::from(source_file);
                     target_path.set_extension("o");
                     ops.set_output_file(&FileArg::loc(target_path.clone()));
+                        let target_path = make_bitcode_filename(&target_path.clone().into_os_string(), bc_opts.bitcode_directory);
+                        bcgen_op.set_output_file(&FileArg::loc(target_path.clone()));
                     Ok(OsString::from(target_path))
                 }
                 Err(msg) => {
@@ -808,7 +810,7 @@ fn collect_events(chan : mpsc::Receiver<Option<Event>>) -> SummaryStats {
                     }
                     Event::BuildFailureUnknownEffect(cmd, exit_code) => {
                         summary.build_failures_unknown_effect += 1;
-                        warn!("Failed build command may affect bitcode coverage '{:?} {:?} = {}'", cmd.bin, cmd.args, exit_code);
+                        error!("Failed compile command may affect bitcode coverage '{:?} {:?} = {}'", cmd.bin, cmd.args, exit_code);
                     }
                     Event::SkippingAssembleOnlyCommand(cmd) => {
                         summary.skipping_assemble_only += 1;

--- a/src/bom/bitcode.rs
+++ b/src/bom/bitcode.rs
@@ -451,8 +451,10 @@ fn build_bitcode_arguments(chan : &mut mpsc::Sender<Option<Event>>,
                     let mut target_path = PathBuf::from(source_file);
                     target_path.set_extension("o");
                     ops.set_output_file(&FileArg::loc(target_path.clone()));
-                        let target_path = make_bitcode_filename(&target_path.clone().into_os_string(), bc_opts.bitcode_directory);
-                        bcgen_op.set_output_file(&FileArg::loc(target_path.clone()));
+                    let target_path = make_bitcode_filename(
+                        &target_path.clone().into_os_string(),
+                        bc_opts.bitcode_directory);
+                    bcgen_op.set_output_file(&FileArg::loc(target_path.clone()));
                     Ok(OsString::from(target_path))
                 }
                 Err(msg) => {


### PR DESCRIPTION
If the compile command did not specify an explicit output file (`cc ... -o
outfile ...`) then build-bom infers one from the input filename.  However, if
there is a chain of multiple operations, that inferred name should be added to
the operation that generates the bitcode output file.  This was previously
missing, causing the attempt to generate the bitcode file for inclusion into the
resulting ELF file to fail.

This also changes the severity (and wording) of the output message to more
appropriately indicate when there are actual problems generating the bitcode and
not just suspicious situations.